### PR TITLE
changes for printing duplicate coverpoints

### DIFF
--- a/riscv_isac/Cached_eval.py
+++ b/riscv_isac/Cached_eval.py
@@ -1,7 +1,40 @@
+from collections import OrderedDict
 import inspect
 
+class lru_cache:
+	def __init__(self,count):
+		self.dict = OrderedDict()
+		self.max_entry = count
 
-class Cached_eval:
+	def __getitem__(self,key):
+		try:
+			ret = self.dict[key]
+			self.dict.move_to_end(key)
+			return ret
+		except :
+			raise KeyError
+
+	def __setitem__(self,key,value):
+		self.dict[key] = value
+		self.dict.move_to_end(key)
+		# Check if we have exceeded number of cache entries
+		# If yes, remove top item as most recent is pushed to back
+		if len(self.dict) > self.max_entry :
+			self.dict.popitem(last=False)
+
+
+	def get(self,key,default=None):
+		try :
+			return self.__getitem__(key)
+		except:
+			return default
+
+
+	def set(self,key,value):
+		self.__setitem__(key,value)
+
+
+class Lazy_eval:
 	def __init__(self,fun):
 		self.function = fun
 		fun_info = inspect.getargspec(fun)
@@ -9,7 +42,7 @@ class Cached_eval:
 		self.defaults = fun_info.defaults
 		if self.defaults is not None:
 			self.defaults = list(self.defaults)
-		self.func_cache = {}
+		self.func_cache = lru_cache(32)
 
 	def process_args(self,args,kwargs):
 		arg_list = []

--- a/riscv_isac/Cached_eval.py
+++ b/riscv_isac/Cached_eval.py
@@ -1,0 +1,36 @@
+import inspect
+
+
+class Cached_eval:
+	def __init__(self,fun):
+		self.function = fun
+		fun_info = inspect.getargspec(fun)
+		self.args = fun_info.args
+		self.defaults = fun_info.defaults
+		if self.defaults is not None:
+			self.defaults = list(self.defaults)
+		self.func_cache = {}
+
+	def process_args(self,args,kwargs):
+		arg_list = []
+		for arg in args:
+			arg_list.append(arg)
+
+		total_args = len(self.args)
+		for i in range(len(arg_list),total_args):
+			if self.args[i] in kwargs.keys():
+				arg_list.append(kwargs[self.args[i]])
+			else:
+				arg_list.append(self.defaults[i-total_args])
+		return tuple(arg_list)
+
+	def __call__(self,*args,**kwargs):
+		argument = self.process_args(args,kwargs)
+		if self.func_cache.get(argument,None) is not None:
+			# print("Found in cache")
+			return self.func_cache[argument]
+
+		# print("Not found")
+		val = self.function(*args,**kwargs)
+		self.func_cache[argument] = val
+		return val

--- a/riscv_isac/Cached_eval.py
+++ b/riscv_isac/Cached_eval.py
@@ -34,7 +34,7 @@ class lru_cache:
 		self.__setitem__(key,value)
 
 
-class Lazy_eval:
+class Cached_eval:
 	def __init__(self,fun):
 		self.function = fun
 		fun_info = inspect.getargspec(fun)

--- a/riscv_isac/Cached_eval.py
+++ b/riscv_isac/Cached_eval.py
@@ -35,16 +35,33 @@ class lru_cache:
 
 
 class Cached_eval:
-	def __init__(self,fun):
+	'''
+	Cached eval class is to be used as a wrapper over any function which
+	needs lazy evaluation, ie. cache the return value so that repetitive
+	calls are not made. Here we have a limited cache size of num_cached,
+	which has the most recently used entries.
+	
+	:param fun: the function to be cached
+	:param num_cached: the number of entries in cache, defaults to 2
+	
+	:type fun: function
+	:type num_cached: int
+	'''
+	def __init__(self,fun,num_cached=2):
 		self.function = fun
 		fun_info = inspect.getargspec(fun)
 		self.args = fun_info.args
 		self.defaults = fun_info.defaults
 		if self.defaults is not None:
 			self.defaults = list(self.defaults)
-		self.func_cache = lru_cache(32)
+		self.func_cache = lru_cache(num_cached)
 
 	def process_args(self,args,kwargs):
+		'''
+		Process current call's arguments by adding the default argument values
+		and return full arguments tuple to identify if this is repetitive call
+		or not.
+		'''
 		arg_list = []
 		for arg in args:
 			arg_list.append(arg)
@@ -60,10 +77,11 @@ class Cached_eval:
 	def __call__(self,*args,**kwargs):
 		argument = self.process_args(args,kwargs)
 		if self.func_cache.get(argument,None) is not None:
-			# print("Found in cache")
+			# Found in cache
 			return self.func_cache[argument]
 
-		# print("Not found")
+		# Not found in cache
+		# call the function and store return value in cache
 		val = self.function(*args,**kwargs)
 		self.func_cache[argument] = val
 		return val

--- a/riscv_isac/cgf_normalize.py
+++ b/riscv_isac/cgf_normalize.py
@@ -416,7 +416,7 @@ def alternate(var, size, signed=True, fltr_func=None,scale_func=None):
     #return [(coverpoint,"Alternate") for coverpoint in coverpoints]
 
 
-def expand_cgf(cgf_files, xlen):
+def expand_cgf(cgf_files, xlen,list_duplicate):
     '''
     This function will replace all the abstract functions with their unrolled
     coverpoints
@@ -429,21 +429,31 @@ def expand_cgf(cgf_files, xlen):
     '''
 
     cgf = utils.load_cgf(cgf_files)
+    if list_duplicate:
+        print("Found duplicate coverpoints: ")
     for labels, cats in cgf.items():
         if labels != 'datasets':
+            if list_duplicate:
+                print("{0} :".format(labels))
+            count = 0
             for label,node in cats.items():
                 if isinstance(node,dict):
                     if 'abstract_comb' in node:
                         temp = node['abstract_comb']
                         del node['abstract_comb']
                         for coverpoints, coverage in temp.items():
-                            i = 0
                             try:
                                 exp_cp = eval(coverpoints)
                             except Exception as e:
                                 pass
                             else:
                                 for cp,comment in exp_cp:
+                                    prev_len = len(cgf[labels][label])
                                     cgf[labels][label].insert(1,cp,coverage,comment=comment)
+                                    if prev_len == len(cgf[labels][label]):
+                                        count += 1
+                                        if list_duplicate:
+                                            print("\t\t#{0}: {1}".format(count,cp))
+            print("Found total {0} duplicate coverpoints".format(count))
     return dict(cgf)
 

--- a/riscv_isac/cgf_normalize.py
+++ b/riscv_isac/cgf_normalize.py
@@ -454,6 +454,7 @@ def expand_cgf(cgf_files, xlen,list_duplicate):
                                         count += 1
                                         if list_duplicate:
                                             print("\t\t#{0}: {1}".format(count,cp))
-            print("Found total {0} duplicate coverpoints".format(count))
+            if list_duplicate :
+                print("Found total {0} duplicate coverpoints".format(count))
     return dict(cgf)
 

--- a/riscv_isac/cgf_normalize.py
+++ b/riscv_isac/cgf_normalize.py
@@ -416,30 +416,37 @@ def alternate(var, size, signed=True, fltr_func=None,scale_func=None):
     #return [(coverpoint,"Alternate") for coverpoint in coverpoints]
 
 
-def find_duplicates(exp_cp,cgf,coverage,count=0):
+def find_duplicates(exp_cp,cgf,coverage,labels,coverpoints):
     '''
     Helper function for checking and printing duplicate coverpoints while inserting into cgf.
     
-    :param exp_cp: exanded coverpoints
+    :param exp_cp: expanded coverpoints
     :param cgf: the cgf node for current label
     :param coverage: coverage hit count
-    :param count: current count of duplicate coverpoints
+    :param labels: current label
+    :param coverpoints: the coverpoint function which has been expanded 
 
     :type exp_cp: list
     :type cgf: ordereddict
     :type coverage: int
-    :type count: int 
+    :type labels: string
+    :type coverpoints: string
     '''
+    count = 0
     prev_len = len(cgf)
+    out_str = ''
+    out_str += "Label: {0} , Coverpoint: {1}:\n".format(labels, coverpoints)
     for cp,comment in exp_cp:
         cgf.insert(1,cp,coverage,comment=comment)
         curr_len = len(cgf)
         if prev_len == curr_len:
             count += 1
-            logger.debug("\t#{0}: {1}".format(count,cp))
+            out_str += "\t#{0}: {1}\n".format(count,cp)
         else :
             prev_len = curr_len
-    return count
+
+    out_str += "Found {0} duplicate coverpoint(s)".format(count)
+    logger.debug(out_str)
 
 def expand_cgf(cgf_files, xlen,list_duplicate=False,cov_labels=None):
     '''
@@ -461,15 +468,10 @@ def expand_cgf(cgf_files, xlen,list_duplicate=False,cov_labels=None):
 
 
     cgf = utils.load_cgf(cgf_files)
-    if list_duplicate:
-        logger.debug("Found duplicate coverpoints: ")
 
     for labels, cats in cgf.items():
         # if cov_labels is given, then expand only for those labels
         if labels != 'datasets' and (cov_labels is None or cov_labels is not None and labels in cov_labels) :
-            if list_duplicate:
-                logger.debug("{0} :".format(labels))
-            count = 0
             for label,node in cats.items():
                 if isinstance(node,dict):
                     if 'abstract_comb' in node:
@@ -482,10 +484,10 @@ def expand_cgf(cgf_files, xlen,list_duplicate=False,cov_labels=None):
                                 pass
                             else:
                                 if list_duplicate:
-                                    count = find_duplicates(exp_cp,cgf[labels][label],coverage,count)
-                                for cp,comment in exp_cp:
-                                    cgf[labels][label].insert(1,cp,coverage,comment=comment)
-            if list_duplicate :
-                logger.debug("Found total {0} duplicate coverpoints".format(count))
+                                    count = find_duplicates(exp_cp,cgf[labels][label],coverage,labels,coverpoints)
+                                else :
+                                    for cp,comment in exp_cp:
+                                        cgf[labels][label].insert(1,cp,coverage,comment=comment)
+
     return dict(cgf)
 

--- a/riscv_isac/cgf_normalize.py
+++ b/riscv_isac/cgf_normalize.py
@@ -5,6 +5,7 @@ import itertools
 import random
 import copy
 from riscv_isac.fp_dataset import *
+from riscv_isac.Cached_eval import Cached_eval
 
 def twos(val,bits):
     '''
@@ -415,6 +416,16 @@ def alternate(var, size, signed=True, fltr_func=None,scale_func=None):
     #coverpoints = [var + ' == ' + str(d) for d in dataset]
     #return [(coverpoint,"Alternate") for coverpoint in coverpoints]
 
+sp_dataset = Cached_eval(sp_dataset)
+walking_ones = Cached_eval(walking_ones)
+walking_zeros = Cached_eval(walking_zeros)
+byte_count = Cached_eval(byte_count)
+uniform_random = Cached_eval(uniform_random)
+leading_ones = Cached_eval(leading_ones)
+leading_zeros = Cached_eval(leading_zeros)
+trailing_ones = Cached_eval(trailing_ones)
+trailing_zeros = Cached_eval(trailing_zeros)
+alternate = Cached_eval(alternate)
 
 def find_duplicates(exp_cp,cgf,coverage,labels,coverpoints):
     '''

--- a/riscv_isac/fp_dataset.py
+++ b/riscv_isac/fp_dataset.py
@@ -5,6 +5,7 @@ import random
 import sys
 import math
 from decimal import *
+from riscv_isac.Cached_eval import Cached_eval
 
 fzero       = ['0x00000000', '0x80000000']
 fminsubnorm = ['0x00000001', '0x80000001']
@@ -4574,3 +4575,33 @@ def ibm_b29(flen, opcode, ops, seed=10):
 	coverpoints = comments_parser(coverpoints)
 
 	return coverpoints
+
+ibm_b1 = Cached_eval(ibm_b1)
+ibm_b2 = Cached_eval(ibm_b2)
+ibm_b3 = Cached_eval(ibm_b3)
+ibm_b4 = Cached_eval(ibm_b4)
+ibm_b5 = Cached_eval(ibm_b5)
+ibm_b6 = Cached_eval(ibm_b6)
+ibm_b7 = Cached_eval(ibm_b7)
+ibm_b8 = Cached_eval(ibm_b8)
+ibm_b9 = Cached_eval(ibm_b9)
+ibm_b10 = Cached_eval(ibm_b10)
+ibm_b11 = Cached_eval(ibm_b11)
+ibm_b12 = Cached_eval(ibm_b12)
+ibm_b13 = Cached_eval(ibm_b13)
+ibm_b14 = Cached_eval(ibm_b14)
+ibm_b15 = Cached_eval(ibm_b15)
+ibm_b16 = Cached_eval(ibm_b16)
+ibm_b17 = Cached_eval(ibm_b17)
+ibm_b18 = Cached_eval(ibm_b18)
+ibm_b19 = Cached_eval(ibm_b19)
+ibm_b20 = Cached_eval(ibm_b20)
+ibm_b21 = Cached_eval(ibm_b21)
+ibm_b22 = Cached_eval(ibm_b22)
+ibm_b23 = Cached_eval(ibm_b23)
+ibm_b24 = Cached_eval(ibm_b24)
+ibm_b25 = Cached_eval(ibm_b25)
+ibm_b26 = Cached_eval(ibm_b26)
+ibm_b27 = Cached_eval(ibm_b27)
+ibm_b28 = Cached_eval(ibm_b28)
+ibm_b29 = Cached_eval(ibm_b29)

--- a/riscv_isac/main.py
+++ b/riscv_isac/main.py
@@ -105,9 +105,16 @@ def cli(verbose):
         help = "Coverage labels to consider for this run."
 )
 @click.option('--xlen','-x',type=click.Choice(['32','64']),default='32',help="XLEN value for the ISA.")
+@click.option(
+        '--list-duplicate',
+        '-z',
+        is_flag='True',
+        default=False,
+        help='Enable to print out the duplicate coverpoints generated'
+    )
 def coverage(elf,trace_file, window_size, cgf_file, detailed,parser_name, decoder_name, parser_path, decoder_path,output_file, test_label,
-        sig_label, dump,cov_label, xlen):
-    isac(output_file,elf,trace_file, window_size, expand_cgf(cgf_file,int(xlen)), parser_name, decoder_name, parser_path, decoder_path, detailed, test_label,
+        sig_label, dump,cov_label, xlen, list_duplicate):
+    isac(output_file,elf,trace_file, window_size, expand_cgf(cgf_file,int(xlen),list_duplicate,cov_label), parser_name, decoder_name, parser_path, decoder_path, detailed, test_label,
             sig_label, dump, cov_label, int(xlen))
 
 
@@ -165,9 +172,16 @@ def merge(files,detailed,p,cgf_file,output_file,xlen):
         required = True
     )
 @click.option('--xlen','-x',type=click.Choice(['32','64']),default='32',help="XLEN value for the ISA.")
-def normalize(cgf_file,output_file,xlen):
+@click.option(
+        '--list-duplicate',
+        '-z',
+        is_flag='True',
+        default=False,
+        help='Enable to print out the duplicate coverpoints generated'
+    )
+def normalize(cgf_file,output_file,xlen,list_duplicate):
     logger.info("Writing normalized CGF to "+str(output_file))
     with open(output_file,"w") as outfile:
-        utils.dump_yaml(expand_cgf(cgf_file,int(xlen)),outfile)
+        utils.dump_yaml(expand_cgf(cgf_file,int(xlen),list_duplicate),outfile)
 
 


### PR DESCRIPTION
Task1 : Explicitly specify redundant coverpoints in the terminal messages - The normalization functions used to abstract representations of coverpoints can potentially produce duplicate coverpoints. It is desirable to identify and optimize these to reduce the time taken to normalize a CGF. In order to do this, the duplicate coverpoints need to be printed out in the generated logs (enabled by a switch)

Task2 : Improve CGF normalization time by caching - The coverage computation can take
multiple days due to the huge normalization overheads in the CGF (F & D extensions have been
observed to have this problem). During the normalization phase of the CGF many function calls
are made which generate the coverpoints necessary. Most of these function calls are repetitive
and return the same values. Using some caching mechanism to perform selective function calls
would drastically reduce CGF normalization times