### PR TITLE
Pext ov flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2022-02-10
+- Added vxsat to supported csr_regs
+- Added comments to coverpoint functions for P-ext
+- Removed unused tuple type for bit_width parameters in P-ext coverpoint functions
+
 ## [0.10.0] - 2022-01-27
 - Added support for instructions from B extension.
 - Bug fix for bgeu instruction.

--- a/riscv_isac/__init__.py
+++ b/riscv_isac/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'info@incoresemi.com'
-__version__ = '0.10.0'
+__version__ = '0.10.1'

--- a/riscv_isac/cgf_normalize.py
+++ b/riscv_isac/cgf_normalize.py
@@ -28,19 +28,25 @@ def twos(val,bits):
     return val
 
 def simd_val_comb(xlen, bit_width, signed=True):
-    if type(bit_width)==tuple:
-        bit_width1, bit_width2 = bit_width
-    else:
-        bit_width1, bit_width2 = bit_width, bit_width
+    '''
+    This function returns coverpoints for operands rs1 and rs2 holding SIMD values. A set of coverpoints will be produced for each SIMD element.
+
+    :param xlen: size of the integer registers
+    :param bit_width: size of each SIMD element
+    :param signed: whether the SIMD elements are signed or unsigned
+
+    :type xlen: int
+    :type bit_width: int
+    :type signed: bool
+    '''
 
     fmt = {8: 'b', 16: 'h', 32: 'w', 64: 'd'}
-    sz1 = fmt[bit_width1]
-    sz2 = fmt[bit_width2]
-    var_num = xlen//bit_width1
+    sz = fmt[bit_width]
+    var_num = xlen//bit_width
     coverpoints = []
     for i in range(var_num):
-        var1 = f'rs1_{sz1}{i}_val'
-        var2 = f'rs2_{sz2}{i}_val'
+        var1 = f'rs1_{sz}{i}_val'
+        var2 = f'rs2_{sz}{i}_val'
         if (signed):
             coverpoints += [(f'{var1} > 0 and {var2} > 0','simd_val_comb')]
             coverpoints += [(f'{var1} > 0 and {var2} < 0','simd_val_comb')]
@@ -54,16 +60,22 @@ def simd_val_comb(xlen, bit_width, signed=True):
 
     return coverpoints
 
-def simd_base_val(rs, xlen, _bit_width, signed=True):
-    fmt = {8: 'b', 16: 'h', 32: 'w', 64: 'd'}
+def simd_base_val(rs, xlen, bit_width, signed=True):
+    '''
+    This function returns datasets for an operand holding SIMD values. One set of data will be produced for each SIMD element.
 
-    if type(_bit_width)==tuple:
-        if (rs=="rs1"):
-            bit_width, not_used = _bit_width
-        else:
-            not_used, bit_width = _bit_width
-    else:
-        bit_width, not_used = _bit_width, _bit_width
+    :param rs: operand name: "rs1" or "rs2"
+    :param xlen: size of the integer registers
+    :param bit_width: size of each SIMD element
+    :param signed: whether the SIMD elements are signed or unsigned
+
+    :type rs: str
+    :type xlen: int
+    :type bit_width: int
+    :type signed: bool
+    '''
+
+    fmt = {8: 'b', 16: 'h', 32: 'w', 64: 'd'}
 
     sz = fmt[bit_width]
     var_num = xlen//bit_width
@@ -87,7 +99,16 @@ def simd_base_val(rs, xlen, _bit_width, signed=True):
     return coverpoints
 
 def simd_imm_val(imm, bit_width):
-    usign_val = (2**(bit_width))
+    '''
+    This function returns coverpoints for unsigned immediate operands, between 0 .. ((2**bit_width)-1)
+
+    :param imm: name of the immediate operand.
+    :param bit_width: bit width of the immediate operand
+
+    :type imm: str
+    :type bit_width: int
+    '''
+    usign_val = 2**bit_width
     coverpoints = []
     for i in range(usign_val):
         coverpoints += [(f'{imm} == {i}','simd_imm_val')]

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -222,7 +222,8 @@ class csr_registers(MutableMapping):
             "scause": int('142',16),
             "stval": int('143',16),
             "sip": int('144',16),
-            "satp": int('180',16)
+            "satp": int('180',16),
+            "vxsat": int('009',16)
         }
         for i in range(16):
             self.csr_regs["pmpaddr"+str(i)] = int('3B0',16)+i
@@ -289,7 +290,6 @@ class archState:
         else:
             self.f_rf = ['0000000000000000']*32
             self.fcsr = 0
-        self.vxsat = 0
         self.pc = 0
 
 class statistics:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.0
+current_version = 0.10.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = [ ]
 
 setup(
     name='riscv_isac',
-    version='0.10.0',
+    version='0.10.1',
     description="RISC-V ISAC",
     long_description=readme + '\n\n',
     classifiers=[


### PR DESCRIPTION
- Added vxsat to supported csr_regs
- Added comments to coverpoint functions for P-ext
- Removed unused tuple type for bit_width parameters in P-ext coverpoint functions
