### PR TITLE
Change to funct3 of of 'csrrci' instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [0.10.2] - 2022-03-15
 - Added method to generate data patterns for bitmanip instructions
--
+- Bug fix for csrrci instruction
+
 ## [0.10.1] - 2022-02-10
 - Added vxsat to supported csr_regs
 - Added comments to coverpoint functions for P-ext

--- a/riscv_isac/plugins/internaldecoder.py
+++ b/riscv_isac/plugins/internaldecoder.py
@@ -1363,7 +1363,7 @@ class disassembler():
             instrObj.instr_name = 'csrrsi'
             instrObj.rs1 = None
             instrObj.zimm = rs1[0]
-        if funct3 == 0b101:
+        if funct3 == 0b111:
             instrObj.instr_name = 'csrrci'
             instrObj.rs1 = None
             instrObj.zimm = rs1[0]


### PR DESCRIPTION
The correct value of funct3 for `csrrci` is `0b111`. The value of funct3 for `csrrci` in `internaldecoder.py` is given as 0b101. This bug is identified and will be corrected after merging this change. The change made is updated in 'CHANGELOG.md'.