### PR TITLE
Decrease coverage calculation time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2022-02-10
+- Parallelized coverage computation.
+- Added feature to remove coverpoints when hit.
+- Added CLI option to specify number of processes to be spawned.
+- Added CLI option to turn on/off feature to remove hit coverpoints.
+
 ## [0.10.1] - 2022-02-10
 - Added vxsat to supported csr_regs
 - Added comments to coverpoint functions for P-ext

--- a/docs/source/isac_cov_calc.rst
+++ b/docs/source/isac_cov_calc.rst
@@ -4,7 +4,7 @@ Performance improvements to ISAC
 
 Coverage computation in ISAC is an iterative process where all coverpoints
 are evaluated for every instruction. This causes an exponential increase in coverage
-computation time as the number of coverage increases. Following are methods leveraged to produce
+computation time as the number of coverpoints increases. Following are methods leveraged to produce
 performance improvements to ISAC.
 
 Parallelized coverage calculation
@@ -12,7 +12,7 @@ Parallelized coverage calculation
 
 Parallelization is one way to reduce the time taken to compute the coverage.
 Parallelization of coverage computation is achieved by the parallelization of ``compute_per_line()``
-method in ``coverage.py`` file. The implementation resorts to use of queues to relay statistics of hit
+method in ``coverage.py`` file. The implementation resorts to the use of queues to relay statistics of hit
 coverpoint back to the main process.
 
 Usage
@@ -33,7 +33,7 @@ The default number of processes spawned is 1
 Removal of Hit Coverpoints from CGF Dictionary
 ##############################################
 
-For archetectural testing, it is enough if a coverpoint is hit just once and has impact on the signature. When this feature 
+For architectural testing, it is enough if a coverpoint is hit just once and has impact on the signature. When this feature 
 is enabled, coverpoints would be deleted from the working CGF dictionary once hit to avoid evaluating it for all subsequent
 instructions. 
 
@@ -43,6 +43,6 @@ This feature can be enabled using the ``--no-count`` option while running ISAC. 
 
     riscv_isac --verbose info coverage -d -t add-01.log --parser-name c_sail --decoder-name internaldecoder -o coverage.rpt --sig-label begin_signature end_signature --test-label rvtest_code_begin rvtest_code_end -e add-01.elf -c dataset.cgf -c rv32i.cgf -x 32 -l add --no-count
 
-``--no-count`` option essentially stores the coverpoints when hit and then deletes them from the CGF dictionary at the end of every iteration
+When ``--no-count`` option supplied, the hit coverpoints are stored and are then deleted from the CGF dictionary at the end of every iteration
 
 This feature is off by default.

--- a/docs/source/isac_cov_calc.rst
+++ b/docs/source/isac_cov_calc.rst
@@ -1,11 +1,16 @@
-Parallelized coverage calculation
-=================================
+*******************************
+Performance improvements to ISAC
+********************************
 
 Coverage computation in ISAC is an iterative process where all coverpoints
 are evaluated for every instruction. This causes an exponential increase in coverage
-computation time as the number of coverage increases. To improve the performance of 
-ISAC, coverage computation is parallelized.
+computation time as the number of coverage increases. Following are methods leveraged to produce
+performance improvements to ISAC.
 
+Parallelized coverage calculation
+=================================
+
+Parallelization is one way to reduce the time taken to compute the coverage.
 Parallelization of coverage computation is achieved by the parallelization of ``compute_per_line()``
 method in ``coverage.py`` file. The implementation resorts to use of queues to relay statistics of hit
 coverpoint back to the main process.
@@ -24,3 +29,20 @@ and its respective coverpoints. The updated cgf dictionary and coverpoint hit st
 The cgf dictionary and the statistics are merged before continuing further.
 
 The default number of processes spawned is 1
+
+Removal of Hit Coverpoints from CGF Dictionary
+==============================================
+
+For archetectural testing, it is enough if a coverpoint is hit just once and has impact on the signature. When this feature 
+is enabled, coverpoints would be deleted from the working CGF dictionary once hit to avoid evaluating it for all subsequent
+instructions. 
+
+Usage
+~~~~~
+This feature can be enabled using the ``--no-count`` option while running ISAC. As an example, ::
+
+    riscv_isac --verbose info coverage -d -t add-01.log --parser-name c_sail --decoder-name internaldecoder -o coverage.rpt --sig-label begin_signature end_signature --test-label rvtest_code_begin rvtest_code_end -e add-01.elf -c dataset.cgf -c rv32i.cgf -x 32 -l add --no-count
+
+``--no-count`` option essentially stores the coverpoints when hit and then deletes them from the CGF dictionary at the end of every iteration
+
+This feature is off by default.

--- a/docs/source/isac_cov_calc.rst
+++ b/docs/source/isac_cov_calc.rst
@@ -1,4 +1,4 @@
-*******************************
+********************************
 Performance improvements to ISAC
 ********************************
 
@@ -8,7 +8,7 @@ computation time as the number of coverage increases. Following are methods leve
 performance improvements to ISAC.
 
 Parallelized coverage calculation
-=================================
+#################################
 
 Parallelization is one way to reduce the time taken to compute the coverage.
 Parallelization of coverage computation is achieved by the parallelization of ``compute_per_line()``
@@ -16,8 +16,8 @@ method in ``coverage.py`` file. The implementation resorts to use of queues to r
 coverpoint back to the main process.
 
 Usage
-~~~~~
-The number of processes to be spawned for coverage computation can be provided using
+*****
+The number of processes to be spawned for coverage computation can be provided using,
 ``--procs`` or ``-p`` option while running ISAC. As an example, ::
     
     riscv_isac --verbose info coverage -d -t add-01.log --parser-name c_sail --decoder-name internaldecoder -o coverage.rpt --sig-label begin_signature end_signature --test-label rvtest_code_begin rvtest_code_end -e add-01.elf -c dataset.cgf -c rv32i.cgf -x 32 -l add --procs 3
@@ -31,14 +31,14 @@ The cgf dictionary and the statistics are merged before continuing further.
 The default number of processes spawned is 1
 
 Removal of Hit Coverpoints from CGF Dictionary
-==============================================
+##############################################
 
 For archetectural testing, it is enough if a coverpoint is hit just once and has impact on the signature. When this feature 
 is enabled, coverpoints would be deleted from the working CGF dictionary once hit to avoid evaluating it for all subsequent
 instructions. 
 
 Usage
-~~~~~
+*****
 This feature can be enabled using the ``--no-count`` option while running ISAC. As an example, ::
 
     riscv_isac --verbose info coverage -d -t add-01.log --parser-name c_sail --decoder-name internaldecoder -o coverage.rpt --sig-label begin_signature end_signature --test-label rvtest_code_begin rvtest_code_end -e add-01.elf -c dataset.cgf -c rv32i.cgf -x 32 -l add --no-count

--- a/docs/source/parallel_cov.rst
+++ b/docs/source/parallel_cov.rst
@@ -1,0 +1,20 @@
+Parallelized coverage calculation
+=================================
+
+Coverage computation in ISAC is an iterative process where all coverpoints
+are evaluated for every instruction. This causes an exponential increase in coverage
+computation time as the number of coverage increases. To improve the performance of 
+ISAC, coverage computation is parallelized.
+
+Parallelization of coverage computation is achieved by the parallelization of ``compute_per_line()``
+method in ``coverage.py`` file. The implementation resorts to use of queues to relay statistics of hit
+coverpoint back to the main process.
+
+Usage
+~~~~~
+The number of processes to be spawned for coverage computation can be provided using
+``--procs`` or ``-p`` option while running ISAC. As an example, ::
+    
+    riscv_isac --verbose info coverage -d -t add-01.log --parser-name c_sail --decoder-name internaldecoder -o coverage.rpt --sig-label begin_signature end_signature --test-label rvtest_code_begin rvtest_code_end -e add-01.elf -c dataset.cgf -c rv32i.cgf -x 32 -l add --procs 3
+
+The default number of processes spawned is 1

--- a/docs/source/parallel_cov.rst
+++ b/docs/source/parallel_cov.rst
@@ -17,4 +17,10 @@ The number of processes to be spawned for coverage computation can be provided u
     
     riscv_isac --verbose info coverage -d -t add-01.log --parser-name c_sail --decoder-name internaldecoder -o coverage.rpt --sig-label begin_signature end_signature --test-label rvtest_code_begin rvtest_code_end -e add-01.elf -c dataset.cgf -c rv32i.cgf -x 32 -l add --procs 3
 
+The above command partitions the supplied CGF file into three different sets based on the coverlabels. Three processes would be
+spawned and are supplied with a part of the partitioned CGF file dictionary. Each of the processes are asynchronously supplied with ``instructionObject`` 
+objects via independent queues. The processes compute coverage independently against the decoded ``instructionObject`` with its own set of coverlabels 
+and its respective coverpoints. The updated cgf dictionary and coverpoint hit statistics are relayed back to the main process through a queue.
+The cgf dictionary and the statistics are merged before continuing further.
+
 The default number of processes spawned is 1

--- a/riscv_isac/__init__.py
+++ b/riscv_isac/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'info@incoresemi.com'
-__version__ = '0.11.0'
+__version__ = '0.12.0'

--- a/riscv_isac/__init__.py
+++ b/riscv_isac/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'info@incoresemi.com'
-__version__ = '0.10.1'
+__version__ = '0.11.0'

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -986,7 +986,7 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, addr_pairs
         stats_queue.close()
 
 def compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xlen, addr_pairs
-        , dump, cov_labels, sig_addrs, window_size, no_count=True, procs=1):
+        , dump, cov_labels, sig_addrs, window_size, no_count=False, procs=1):
     '''Compute the Coverage'''
 
     global arch_state

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -532,373 +532,7 @@ def simd_val_unpack(val_comb, op_width, op_name, val, local_dict):
     if simd_size == op_width:
         local_dict[f"{op_name}_val"]=elm_val
 
-def compute_per_line(instr, cgf, xlen, addr_pairs,  sig_addrs):
-    '''
-    This function checks if the current instruction under scrutiny matches a
-    particular coverpoint of interest. If so, it updates the coverpoints and
-    return the same.
-
-    :param instr: an instructionObject of the single instruction currently parsed
-    :param cgf: a cgf against which coverpoints need to be checked for.
-    :param xlen: Max xlen of the trace
-    :param addr_pairs: pairs of start and end addresses for which the coverage needs to be updated
-
-    :type instr: :class:`instructionObject`
-    :type cgf: dict
-    :type xlen: int
-    :type addr_pairs: (int, int)
-    '''
-    global arch_state
-    global csr_regfile
-    global stats
-    global result_count
-
-    mnemonic = instr.mnemonic
-    commitvalue = instr.reg_commit
-
-    # assign default values to operands
-    rs1 = 0
-    rs2 = 0
-    rs3 = 0
-    rd  = 0
-    rs1_type = 'x'
-    rs2_type = 'x'
-    rs3_type = 'f'
-    rd_type = 'x'
-
-    csr_addr = 0
-
-    # create signed/unsigned conversion params
-    if xlen == 32:
-        unsgn_sz = '>I'
-        sgn_sz = '>i'
-    else:
-        unsgn_sz = '>Q'
-        sgn_sz = '>q'
-
-    # if instruction is empty then return
-    if instr is None:
-        return cgf
-
-    # check if instruction lies within the valid region of interest
-    if addr_pairs:
-        if any([instr.instr_addr >= saddr and instr.instr_addr < eaddr for saddr,eaddr in addr_pairs]):
-            enable = True
-        else:
-            enable = False
-    else:
-        enable=True
-
-    # capture the operands and their values from the regfile
-    if instr.rs1 is not None:
-        rs1 = instr.rs1[0]
-        rs1_type = instr.rs1[1]
-    if instr.rs2 is not None:
-        rs2 = instr.rs2[0]
-        rs2_type = instr.rs2[1]
-    if instr.rs3 is not None:
-        rs3 = instr.rs3[0]
-        rs3_type = instr.rs3[1]
-
-    if instr.rd is not None:
-        rd = instr.rd[0]
-        is_rd_valid = True
-        rd_type = instr.rd[1]
-    else:
-        is_rd_valid = False
-
-    if instr.imm is not None:
-        imm_val = instr.imm
-    if instr.shamt is not None:
-        imm_val = instr.shamt
-
-    # special value conversion based on signed/unsigned operations
-    if instr.instr_name in unsgn_rs1:
-        rs1_val = struct.unpack(unsgn_sz, bytes.fromhex(arch_state.x_rf[rs1]))[0]
-    elif instr.is_rvp:
-        rs1_val = struct.unpack(unsgn_sz, bytes.fromhex(arch_state.x_rf[rs1]))[0]
-        if instr.rs1_nregs == 2:
-            rs1_hi_val = struct.unpack(unsgn_sz, bytes.fromhex(arch_state.x_rf[rs1+1]))[0]
-            rs1_val = (rs1_hi_val << 32) | rs1_val
-    elif rs1_type == 'x':
-        rs1_val = struct.unpack(sgn_sz, bytes.fromhex(arch_state.x_rf[rs1]))[0]
-        if instr.instr_name in ["fmv.w.x"]:
-            rs1_val = '0x' + (arch_state.x_rf[rs1]).lower()
-    elif rs1_type == 'f':
-        rs1_val = struct.unpack(sgn_sz, bytes.fromhex(arch_state.f_rf[rs1]))[0]
-        if instr.instr_name in ["fadd.s","fsub.s","fmul.s","fdiv.s","fsqrt.s","fmadd.s","fmsub.s","fnmadd.s","fnmsub.s","fmax.s","fmin.s","feq.s","flt.s","fle.s","fmv.x.w","fmv.w.x","fcvt.wu.s","fcvt.s.wu","fcvt.w.s","fcvt.s.w","fsgnj.s","fsgnjn.s","fsgnjx.s","fclass.s"]:
-            rs1_val = '0x' + (arch_state.f_rf[rs1]).lower()
-
-    if instr.instr_name in unsgn_rs2:
-        rs2_val = struct.unpack(unsgn_sz, bytes.fromhex(arch_state.x_rf[rs2]))[0]
-    elif instr.is_rvp:
-        rs2_val = struct.unpack(unsgn_sz, bytes.fromhex(arch_state.x_rf[rs2]))[0]
-        if instr.rs2_nregs == 2:
-            rs2_hi_val = struct.unpack(unsgn_sz, bytes.fromhex(arch_state.x_rf[rs2+1]))[0]
-            rs2_val = (rs2_hi_val << 32) | rs2_val
-    elif rs2_type == 'x':
-        rs2_val = struct.unpack(sgn_sz, bytes.fromhex(arch_state.x_rf[rs2]))[0]
-    elif rs2_type == 'f':
-        rs2_val = struct.unpack(sgn_sz, bytes.fromhex(arch_state.f_rf[rs2]))[0]
-        if instr.instr_name in ["fadd.s","fsub.s","fmul.s","fdiv.s","fmadd.s","fmsub.s","fnmadd.s","fnmsub.s","fmax.s","fmin.s","feq.s","flt.s","fle.s","fsgnj.s","fsgnjn.s","fsgnjx.s"]:
-            rs2_val = '0x' + (arch_state.f_rf[rs2]).lower()
-
-    sig_update = False
-    if instr.instr_name in ['sh','sb','sw','sd','c.sw','c.sd','c.swsp','c.sdsp'] and sig_addrs:
-        store_address = rs1_val + imm_val
-        for start, end in sig_addrs:
-            if store_address >= start and store_address <= end:
-                sig_update = True
-                break
-
-    if sig_update: # writing result operands of last non-store instruction to the signature region
-        result_count = result_count - 1
-    else:
-        result_count = instr.rd_nregs
-
-    if instr.instr_name in ["fmadd.s","fmsub.s","fnmadd.s","fnmsub.s"]:
-        rs3_val = '0x' + (arch_state.f_rf[rs3]).lower()
-
-    if instr.instr_name in ['csrrwi']:
-        arch_state.fcsr = instr.zimm
-
-    if instr.instr_name in ["fadd.s","fsub.s","fmul.s","fdiv.s","fsqrt.s","fmadd.s","fmsub.s","fnmadd.s","fnmsub.s","fmax.s","fmin.s","feq.s","flt.s","fle.s","fmv.x.w","fmv.w.x","fcvt.wu.s","fcvt.s.wu","fcvt.w.s","fcvt.s.w","fsgnj.s","fsgnjn.s","fsgnjx.s","fclass.s"]:
-         rm = instr.rm
-         if(rm==7 or rm==None):
-              rm_val = arch_state.fcsr
-         else:
-              rm_val = rm
-
-    arch_state.pc = instr.instr_addr
-
-    # the ea_align variable is used by the eval statements of the
-    # coverpoints for conditional ops and memory ops
-    if instr.instr_name in ['jal','bge','bgeu','blt','bltu','beq','bne']:
-        ea_align = (instr.instr_addr+(imm_val<<1)) % 4
-
-    if instr.instr_name == "jalr":
-        ea_align = (rs1_val + imm_val) % 4
-
-    if instr.instr_name in ['sw','sh','sb','lw','lhu','lh','lb','lbu','lwu','flw','fsw']:
-        ea_align = (rs1_val + imm_val) % 4
-    if instr.instr_name in ['ld','sd']:
-        ea_align = (rs1_val + imm_val) % 8
-
-    local_dict={}
-    for i in csr_regfile.csr_regs:
-        local_dict[i] = int(csr_regfile[i],16)
-
-    local_dict['xlen'] = xlen
-
-    if enable :
-        for cov_labels,value in cgf.items():
-            if cov_labels != 'datasets':
-                if 'opcode' in value:
-                    if instr.instr_name in value['opcode']:
-                        if stats.code_seq:
-                            logger.error('Found a coverpoint without sign Upd ' + str(stats.code_seq))
-                            stats.stat3.append('\n'.join(stats.code_seq))
-                            stats.code_seq = []
-                            stats.covpt = []
-                            stats.ucovpt = []
-                            stats.ucode_seq = []
-
-                        if value['opcode'][instr.instr_name] == 0:
-                            stats.ucovpt.append('opcode : ' + instr.instr_name)
-                        stats.covpt.append('opcode : ' + instr.instr_name)
-                        value['opcode'][instr.instr_name] += 1
-                        if 'rs1' in value and 'x'+str(rs1) in value['rs1']:
-                            if value['rs1']['x'+str(rs1)] == 0:
-                                stats.ucovpt.append('rs1 : ' + 'x'+str(rs1))
-                            stats.covpt.append('rs1 : ' + 'x'+str(rs1))
-                            value['rs1']['x'+str(rs1)] += 1
-                        if 'rs2' in value and 'x'+str(rs2) in value['rs2']:
-                            if value['rs2']['x'+str(rs2)] == 0:
-                                stats.ucovpt.append('rs2 : ' + 'x'+str(rs2))
-                            stats.covpt.append('rs2 : ' + 'x'+str(rs2))
-                            value['rs2']['x'+str(rs2)] += 1
-                        if 'rd' in value and is_rd_valid and 'x'+str(rd) in value['rd']:
-                            if value['rd']['x'+str(rd)] == 0:
-                                stats.ucovpt.append('rd : ' + 'x'+str(rd))
-                            stats.covpt.append('rd : ' + 'x'+str(rd))
-                            value['rd']['x'+str(rd)] += 1
-
-                        if 'rs1' in value and 'f'+str(rs1) in value['rs1']:
-                            if value['rs1']['f'+str(rs1)] == 0:
-                                stats.ucovpt.append('rs1 : ' + 'f'+str(rs1))
-                            stats.covpt.append('rs1 : ' + 'f'+str(rs1))
-                            value['rs1']['f'+str(rs1)] += 1
-                        if 'rs2' in value and 'f'+str(rs2) in value['rs2']:
-                            if value['rs2']['f'+str(rs2)] == 0:
-                                stats.ucovpt.append('rs2 : ' + 'f'+str(rs2))
-                            stats.covpt.append('rs2 : ' + 'f'+str(rs2))
-                            value['rs2']['f'+str(rs2)] += 1
-                        if 'rs3' in value and 'f'+str(rs3) in value['rs3']:
-                            if value['rs3']['f'+str(rs3)] == 0:
-                                stats.ucovpt.append('rs3 : ' + 'f'+str(rs3))
-                            stats.covpt.append('rs3 : ' + 'f'+str(rs3))
-                            value['rs3']['f'+str(rs3)] += 1
-                        if 'rd' in value and is_rd_valid and 'f'+str(rd) in value['rd']:
-                            if value['rd']['f'+str(rd)] == 0:
-                                stats.ucovpt.append('rd : ' + 'f'+str(rd))
-                            stats.covpt.append('rd : ' + 'f'+str(rd))
-                            value['rd']['f'+str(rd)] += 1
-
-                        if 'op_comb' in value and len(value['op_comb']) != 0 :
-                            for coverpoints in value['op_comb']:
-                                if eval(coverpoints):
-                                    if cgf[cov_labels]['op_comb'][coverpoints] == 0:
-                                        stats.ucovpt.append(str(coverpoints))
-                                    stats.covpt.append(str(coverpoints))
-                                    cgf[cov_labels]['op_comb'][coverpoints] += 1
-                        if 'val_comb' in value and len(value['val_comb']) != 0:
-                            if instr.instr_name in ['fadd.s',"fsub.s","fmul.s","fdiv.s","fmax.s","fmin.s","feq.s","flt.s","fle.s","fsgnj.s","fsgnjn.s","fsgnjx.s"]:
-                                    val_key = fmt.extract_fields(32, rs1_val, str(1))
-                                    val_key+= " and "
-                                    val_key+= fmt.extract_fields(32, rs2_val, str(2))
-                                    val_key+= " and "
-                                    val_key+= 'rm == '+ str(rm_val)
-                                    l=[0]
-                                    l[0] = val_key
-                                    val_key = l
-                                    if(val_key[0] in cgf[cov_labels]['val_comb']):
-                                        if cgf[cov_labels]['val_comb'][val_key[0]] == 0:
-                                            stats.ucovpt.append(str(val_key[0]))
-                                        stats.covpt.append(str(val_key[0]))
-                                        cgf[cov_labels]['val_comb'][val_key[0]] += 1
-                            elif instr.instr_name in ["fsqrt.s","fmv.x.w","fmv.w.x","fcvt.wu.s","fcvt.s.wu","fcvt.w.s","fcvt.s.w","fclass.s"]:
-                                    val_key = fmt.extract_fields(32, rs1_val, str(1))
-                                    val_key+= " and "
-                                    val_key+= 'rm == '+ str(rm_val)
-                                    l=[0]
-                                    l[0] = val_key
-                                    val_key = l
-                                    if(val_key[0] in cgf[cov_labels]['val_comb']):
-                                        if cgf[cov_labels]['val_comb'][val_key[0]] == 0:
-                                            stats.ucovpt.append(str(val_key[0]))
-                                        stats.covpt.append(str(val_key[0]))
-                                        cgf[cov_labels]['val_comb'][val_key[0]] += 1
-                            elif instr.instr_name in ["fmadd.s","fmsub.s","fnmadd.s","fnmsub.s"]:
-                                    val_key = fmt.extract_fields(32, rs1_val, str(1))
-                                    val_key+= " and "
-                                    val_key+= fmt.extract_fields(32, rs2_val, str(2))
-                                    val_key+= " and "
-                                    val_key+= fmt.extract_fields(32, rs3_val, str(3))
-                                    val_key+= " and "
-                                    val_key+= 'rm == '+ str(rm_val)
-                                    l=[0]
-                                    l[0] = val_key
-                                    val_key = l
-                                    if(val_key[0] in cgf[cov_labels]['val_comb']):
-                                        if cgf[cov_labels]['val_comb'][val_key[0]] == 0:
-                                            stats.ucovpt.append(str(val_key[0]))
-                                        stats.covpt.append(str(val_key[0]))
-                                        cgf[cov_labels]['val_comb'][val_key[0]] += 1
-                            else:
-                                lcls=locals().copy()
-                                if instr.is_rvp and "rs1" in value:
-                                    op_width = 64 if instr.rs1_nregs == 2 else xlen
-                                    simd_val_unpack(value['val_comb'], op_width, "rs1", rs1_val, lcls)
-                                if instr.is_rvp and "rs2" in value:
-                                    op_width = 64 if instr.rs2_nregs == 2 else xlen
-                                    simd_val_unpack(value['val_comb'], op_width, "rs2", rs2_val, lcls)
-                                for coverpoints in value['val_comb']:
-                                    if eval(coverpoints, globals(), lcls):
-                                        if cgf[cov_labels]['val_comb'][coverpoints] == 0:
-                                            stats.ucovpt.append(str(coverpoints))
-                                        stats.covpt.append(str(coverpoints))
-                                        cgf[cov_labels]['val_comb'][coverpoints] += 1
-                        if 'abstract_comb' in value \
-                                and len(value['abstract_comb']) != 0 :
-                            for coverpoints in value['abstract_comb']:
-                                if eval(coverpoints):
-                                    if cgf[cov_labels]['abstract_comb'][coverpoints] == 0:
-                                        stats.ucovpt.append(str(coverpoints))
-                                    stats.covpt.append(str(coverpoints))
-                                    cgf[cov_labels]['abstract_comb'][coverpoints] += 1
-
-                        if 'csr_comb' in value and len(value['csr_comb']) != 0:
-                            for coverpoints in value['csr_comb']:
-                                if eval(coverpoints, {"__builtins__":None}, local_dict):
-                                    if cgf[cov_labels]['csr_comb'][coverpoints] == 0:
-                                        stats.ucovpt.append(str(coverpoints))
-                                    stats.covpt.append(str(coverpoints))
-                                    cgf[cov_labels]['csr_comb'][coverpoints] += 1
-                elif 'opcode' not in value:
-                    if 'csr_comb' in value and len(value['csr_comb']) != 0:
-                        for coverpoints in value['csr_comb']:
-                            if eval(coverpoints, {"__builtins__":None}, local_dict):
-                                if cgf[cov_labels]['csr_comb'][coverpoints] == 0:
-                                    stats.ucovpt.append(str(coverpoints))
-                                stats.covpt.append(str(coverpoints))
-                                cgf[cov_labels]['csr_comb'][coverpoints] += 1
-        if stats.covpt:
-            if mnemonic is not None :
-                stats.code_seq.append('[' + str(hex(instr.instr_addr)) + ']:' + mnemonic)
-            else:
-                stats.code_seq.append('[' + str(hex(instr.instr_addr)) + ']:' + instr.instr_name)
-        if stats.ucovpt:
-            if mnemonic is not None :
-                stats.ucode_seq.append('[' + str(hex(instr.instr_addr)) + ']:' + mnemonic)
-            else:
-                stats.ucode_seq.append('[' + str(hex(instr.instr_addr)) + ']:' + instr.instr_name)
-
-    if instr.instr_name in ['sh','sb','sw','sd','c.sw','c.sd','c.swsp','c.sdsp'] and sig_addrs:
-        store_address = rs1_val + imm_val
-        store_val = '0x'+arch_state.x_rf[rs2]
-        for start, end in sig_addrs:
-            if store_address >= start and store_address <= end:
-                logger.debug('Signature update : ' + str(hex(store_address)))
-                stats.stat5.append((store_address, store_val, stats.ucovpt, stats.code_seq))
-                stats.cov_pt_sig += stats.covpt
-                if result_count <= 0:
-                    if stats.ucovpt:
-                        stats.stat1.append((store_address, store_val, stats.ucovpt, stats.ucode_seq))
-                        stats.last_meta = [store_address, store_val, stats.ucovpt, stats.ucode_seq]
-                        stats.ucovpt = []
-                    elif stats.covpt:
-                        _log = 'Op without unique coverpoint updates Signature\n'
-                        _log += ' -- Code Sequence:\n'
-                        for op in stats.code_seq:
-                            _log += '      ' + op + '\n'
-                        _log += ' -- Signature Address: {0} Data: {1}\n'.format(
-                                str(hex(store_address)), store_val)
-                        _log += ' -- Redundant Coverpoints hit by the op\n'
-                        for c in stats.covpt:
-                            _log += '      - ' + str(c) + '\n'
-                        logger.warn(_log)
-                        stats.stat2.append(_log + '\n\n')
-                        stats.last_meta = [store_address, store_val, stats.covpt, stats.code_seq]
-                    else:
-                        _log = 'Last Coverpoint : ' + str(stats.last_meta[2]) + '\n'
-                        _log += 'Last Code Sequence : \n\t-' + '\n\t-'.join(stats.last_meta[3]) + '\n'
-                        _log +='Current Store : [{0}] : {1} -- Store: [{2}]:{3}\n'.format(\
-                            str(hex(instr.instr_addr)), mnemonic,
-                            str(hex(store_address)),
-                            store_val)
-                        logger.error(_log)
-                        stats.stat4.append(_log + '\n\n')
-
-                    stats.covpt = []
-                    stats.code_seq = []
-                    stats.ucode_seq = []
-
-    if commitvalue is not None:
-        if rd_type == 'x':
-            arch_state.x_rf[int(commitvalue[1])] =  str(commitvalue[2][2:])
-        elif rd_type == 'f':
-            arch_state.f_rf[int(commitvalue[1])] =  str(commitvalue[2][2:])
-
-    csr_commit = instr.csr_commit
-    if csr_commit is not None:
-        for commits in csr_commit:
-            if(commits[0]=="CSR"):
-                csr_regfile[commits[1]] = str(commits[2][2:])
-
-    return cgf
-
-
-def new_compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, addr_pairs, sig_addrs, stats, arch_state, csr_regfile, result_count):
+def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, addr_pairs, sig_addrs, stats, arch_state, csr_regfile, result_count):
     '''
     This function checks if the current instruction under scrutiny matches a
     particular coverpoint of interest. If so, it updates the coverpoints and
@@ -1336,134 +970,98 @@ def compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xle
 
     iterator = iter(parser.__iter__()[0])
     
+        
+    start = time.time()
+    # If number of processors to be spawned is more than that available
+    available_cores = mp.cpu_count()
+    if procs > available_cores:
+        procs = available_cores - 1
+    # Partiton cgf to chunks
+    chunk_len = math.ceil(len(cgf) / procs)
+    chunks = [{k:cgf[k] for k in islice(iter(cgf), chunk_len)} for i in range(0, len(cgf), chunk_len)]
     
-    if procs > 1:
-        
-        start = time.time()
-
-        # If number of processors to be spawned is more than that available
-        available_cores = mp.cpu_count()
-        if procs > available_cores:
-            procs = available_cores - 1
-
-        # Partiton cgf to chunks
-        chunk_len = math.ceil(len(cgf) / procs)
-        chunks = [{k:cgf[k] for k in islice(iter(cgf), chunk_len)} for i in range(0, len(cgf), chunk_len)]
-        
-        queue_list = []
-        process_list = []
-        event_list = []
-
-        cgf_queue_list = []
-        stats_queue_list = []
-
-        #Initialize processes and queues
-        for i in range(len(chunks)):
-            queue_list.append(mp.Queue())
-            cgf_queue_list.append(mp.Queue())
-            stats_queue_list.append(mp.Queue())
-            event_list.append(mp.Event())
-            process_list.append(
-                            mp.Process(target=new_compute_per_line, 
-                                    args=(queue_list[i], event_list[i], cgf_queue_list[i], stats_queue_list[i],
-                                        chunks[i], xlen, addr_pairs, sig_addrs,
-                                        stats, 
-                                        arch_state, 
-                                        csr_regfile,
-                                        result_count
-                                        )
-                                )
+    queue_list = []
+    process_list = []
+    event_list = []
+    cgf_queue_list = []
+    stats_queue_list = []
+    #Initialize processes and queues
+    for i in range(len(chunks)):
+        queue_list.append(mp.Queue())
+        cgf_queue_list.append(mp.Queue())
+        stats_queue_list.append(mp.Queue())
+        event_list.append(mp.Event())
+        process_list.append(
+                        mp.Process(target=compute_per_line, 
+                                args=(queue_list[i], event_list[i], cgf_queue_list[i], stats_queue_list[i],
+                                    chunks[i], xlen, addr_pairs, sig_addrs,
+                                    stats, 
+                                    arch_state, 
+                                    csr_regfile,
+                                    result_count
+                                    )
                             )
-        end = time.time()
-        print(f'Setup time for {procs} processes: {end-start}')
-
-        #Start processes
-        for each in process_list:
-            each.start()
-
-        queue_time = 0
-        for instrObj_temp in iterator:
-            instr = instrObj_temp.instr
-            if instr is None:
-                continue
-            instrObj = (decoder.decode(instrObj_temp = instrObj_temp))[0]
-            
-            start_queue = time.time()
-            # Pass instrObjs to queue
-            for each in queue_list:
-                each.put_nowait(instrObj)
-            end_queue = time.time()
-            queue_time = queue_time + (end_queue - start_queue)
-
-            logger.debug(instrObj)
-            cross_cover_queue.append(instrObj)
-            if(len(cross_cover_queue)>=window_size):
-                for (label,coverpt) in obj_dict.keys():
-                    obj_dict[(label,coverpt)].process(cross_cover_queue, window_size,addr_pairs)
-                cross_cover_queue.pop(0)
-        end = time.time()
-        print(f'Time elapsed for loop: {end - start}')
-        print(f'Total time elapsed for queues: {queue_time}')
-
-        # Signal each processes that instruction list is over
-        for each in event_list:
-            each.set()
+                        )
+    end = time.time()
+    print(f'Setup time for {procs} processes: {end-start}')
+    #Start processes
+    for each in process_list:
+        each.start()
+    queue_time = 0
+    for instrObj_temp in iterator:
+        instr = instrObj_temp.instr
+        if instr is None:
+            continue
+        instrObj = (decoder.decode(instrObj_temp = instrObj_temp))[0]
         
-        # Close all queues
+        start_queue = time.time()
+        # Pass instrObjs to queue
         for each in queue_list:
-            each.close()
-            each.join_thread()
-
-        # Get the renewed cgfs
-        cgf_list = []
-        for each in cgf_queue_list:
-            cgf_list.append(each.get())
-            each.close()
-            each.join_thread()
-
-        # Get each stats
-        stats_list = []
-        for each in stats_queue_list:
-            stats_list.append(each.get())
-            each.close()
-            each.join_thread()
-
-        # Join all processes
-        for each in process_list:
-            each.join()
-
-        end = time.time()
-        print(f'With multiple processes: {end - start}')
-
-        # Merge stats
-        for each in stats_list:
-            stats = stats + each
-
-        # Merge cgfs
-        rcgf = dict()
-        for d in cgf_list:
-            for key, val in d.items():
-                rcgf[key] = val
+            each.put_nowait(instrObj)
+        end_queue = time.time()
+        queue_time = queue_time + (end_queue - start_queue)
+        logger.debug(instrObj)
+        cross_cover_queue.append(instrObj)
+        if(len(cross_cover_queue)>=window_size):
+            for (label,coverpt) in obj_dict.keys():
+                obj_dict[(label,coverpt)].process(cross_cover_queue, window_size,addr_pairs)
+            cross_cover_queue.pop(0)
+    end = time.time()
+    print(f'Time elapsed for loop: {end - start}')
+    print(f'Total time elapsed for queues: {queue_time}')
+    # Signal each processes that instruction list is over
+    for each in event_list:
+        each.set()
     
-    else:
-        rcgf = cgf
-        start = time.time()
-        for instrObj_temp in iterator:
-            instr = instrObj_temp.instr
-            if instr is None:
-                continue
-            instrObj = (decoder.decode(instrObj_temp = instrObj_temp))[0]
-            logger.debug(instrObj)
-            cross_cover_queue.append(instrObj)
-            if(len(cross_cover_queue)>=window_size):
-                for (label,coverpt) in obj_dict.keys():
-                    obj_dict[(label,coverpt)].process(cross_cover_queue, window_size,addr_pairs)
-                cross_cover_queue.pop(0)
-            rcgf = compute_per_line(instrObj, rcgf, xlen,
-                            addr_pairs, sig_addrs)
-        
-        end = time.time()
-        print(f'With single process: {end-start}')
+    # Close all queues
+    for each in queue_list:
+        each.close()
+        each.join_thread()
+    # Get the renewed cgfs
+    cgf_list = []
+    for each in cgf_queue_list:
+        cgf_list.append(each.get())
+        each.close()
+        each.join_thread()
+    # Get each stats
+    stats_list = []
+    for each in stats_queue_list:
+        stats_list.append(each.get())
+        each.close()
+        each.join_thread()
+    # Join all processes
+    for each in process_list:
+        each.join()
+    end = time.time()
+    print(f'With multiple processes: {end - start}')
+    # Merge stats
+    for each in stats_list:
+        stats = stats + each
+    # Merge cgfs
+    rcgf = dict()
+    for d in cgf_list:
+        for key, val in d.items():
+            rcgf[key] = val
 
     ## Check for cross coverage for end instructions
     ## All metric is stored in objects of obj_dict

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -979,7 +979,7 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, addr_pairs
         stats_queue.close()
 
 def compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xlen, addr_pairs
-        , dump, cov_labels, sig_addrs, window_size, no_count = False, procs):
+        , dump, cov_labels, sig_addrs, window_size, no_count=True, procs=1):
     '''Compute the Coverage'''
 
     global arch_state

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -538,16 +538,34 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, addr_pairs
     particular coverpoint of interest. If so, it updates the coverpoints and
     return the same.
 
+    :param queue: A queue thread to push instructionObject
+    :param event: Event object to signal completion of decoding
+    :param cgf_queue: A queue thread to push updated cgf
+    :param stats_queue: A queue thread to push updated `stats` object 
+    
     :param cgf: a cgf against which coverpoints need to be checked for.
     :param xlen: Max xlen of the trace
     :param addr_pairs: pairs of start and end addresses for which the coverage needs to be updated
+    :param sig_addrs: pairs of start and end addresses for which signature update needs to be checked
+    :param stats: `stats` object
+    :param csr_regfile: Architectural state of CSR register file
+    :param result_count:
 
+    :type queue: class`multiprocessing.Queue`
+    :type event: class`multiprocessing.Event`
+    :type cgf_queue: class`multiprocessing.Queue`
+    :type stats_queue: class`multiprocessing.Queue`
     :type instr: :class:`instructionObject`
     :type cgf: dict
     :type xlen: int
     :type addr_pairs: (int, int)
+    :type sig_addrs: (int, int)
+    :type stats: class `statistics`
+    :type csr_regfile: class `csr_registers`
+    :type result_count: int
     '''
 
+    # List to hold hit coverpoints
     hit_covpts = []
 
     while (event.is_set() == False) or (queue.empty() == False):
@@ -699,7 +717,7 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, addr_pairs
                         if 'opcode' in value:
                             if instr.instr_name in value['opcode']:
                                 if stats.code_seq:
-                                    #logger.error('Found a coverpoint without sign Upd ' + str(stats.code_seq))
+                                    logger.error('Found a coverpoint without sign Upd ' + str(stats.code_seq))
                                     stats.stat3.append('\n'.join(stats.code_seq))
                                     stats.code_seq = []
                                     stats.covpt = []
@@ -961,7 +979,7 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, addr_pairs
         stats_queue.close()
 
 def compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xlen, addr_pairs
-        , dump, cov_labels, sig_addrs, window_size, no_count = False, procs = 3):
+        , dump, cov_labels, sig_addrs, window_size, no_count = False, procs):
     '''Compute the Coverage'''
 
     global arch_state

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -2,6 +2,9 @@
 # See LICENSE.incore for details
 # See LICENSE.iitm for details
 
+from itertools import islice
+import pprint
+import time
 import ruamel
 from ruamel.yaml import YAML
 import riscv_isac.utils as utils
@@ -21,7 +24,6 @@ from riscv_isac.plugins.specification import *
 import math
 import multiprocessing as mp
 from collections.abc import MutableMapping
-
 
 unsgn_rs1 = ['sw','sd','sh','sb','ld','lw','lwu','lh','lhu','lb', 'lbu','flw','fld','fsw','fsd',\
         'bgeu', 'bltu', 'sltiu', 'sltu','c.lw','c.ld','c.lwsp','c.ldsp',\
@@ -309,6 +311,8 @@ class statistics:
         - STAT5 : Number of times the signature was overwritten
         '''
 
+        self.xlen = xlen
+        self.flen = flen
 
         self.stat1 = []
         self.stat2 = []
@@ -321,6 +325,24 @@ class statistics:
         self.ucovpt = []
         self.cov_pt_sig = []
         self.last_meta = []
+    
+    def __add__(self, o):
+        temp = statistics(self.xlen, self.flen)
+        temp.stat1 = self.stat1 + o.stat1
+        temp.stat2 = self.stat2 + o.stat2
+        temp.stat3 = self.stat3 + o.stat3
+        temp.stat4 = self.stat4 + o.stat4
+        temp.stat5 = self.stat5 + o.stat5
+
+        temp.code_seq = self.code_seq + o.code_seq
+        temp.ucode_seq = self.ucode_seq + o.ucode_seq
+        temp.covpt = self.covpt + o.covpt
+        temp.ucovpt = self.ucovpt + o.ucovpt
+        temp.cov_pt_sig = self.cov_pt_sig + o.cov_pt_sig
+        temp.last_meta = self.last_meta + o.last_meta
+
+        return temp
+        
 
 def pretty_print_yaml(yaml):
     res = ''''''
@@ -510,7 +532,7 @@ def simd_val_unpack(val_comb, op_width, op_name, val, local_dict):
     if simd_size == op_width:
         local_dict[f"{op_name}_val"]=elm_val
 
-def compute_per_line(instr, cgf, xlen, addr_pairs,  sig_addrs, no_count, procs):
+def compute_per_line(instr, cgf, xlen, addr_pairs,  sig_addrs):
     '''
     This function checks if the current instruction under scrutiny matches a
     particular coverpoint of interest. If so, it updates the coverpoints and
@@ -530,6 +552,7 @@ def compute_per_line(instr, cgf, xlen, addr_pairs,  sig_addrs, no_count, procs):
     global csr_regfile
     global stats
     global result_count
+
     mnemonic = instr.mnemonic
     commitvalue = instr.reg_commit
 
@@ -667,147 +690,141 @@ def compute_per_line(instr, cgf, xlen, addr_pairs,  sig_addrs, no_count, procs):
 
     local_dict['xlen'] = xlen
 
-    
-    def update_covpt(value):
-        print('In update_covpt')
-        if instr.instr_name in value['opcode']:            
-            if stats.code_seq:
-                logger.error('Found a coverpoint without sign Upd ' + str(stats.code_seq))
-                stats.stat3.append('\n'.join(stats.code_seq))
-                stats.code_seq = []
-                stats.covpt = []
-                stats.ucovpt = []
-                stats.ucode_seq = []
+    if enable :
+        for cov_labels,value in cgf.items():
+            if cov_labels != 'datasets':
+                if 'opcode' in value:
+                    if instr.instr_name in value['opcode']:
+                        if stats.code_seq:
+                            logger.error('Found a coverpoint without sign Upd ' + str(stats.code_seq))
+                            stats.stat3.append('\n'.join(stats.code_seq))
+                            stats.code_seq = []
+                            stats.covpt = []
+                            stats.ucovpt = []
+                            stats.ucode_seq = []
 
-            if value['opcode'][instr.instr_name] == 0:
-                stats.ucovpt.append('opcode : ' + instr.instr_name)
-            stats.covpt.append('opcode : ' + instr.instr_name)
-            value['opcode'][instr.instr_name] += 1
-            
-            if 'rs1' in value and 'x'+str(rs1) in value['rs1']:
-                if value['rs1']['x'+str(rs1)] == 0:
-                    stats.ucovpt.append('rs1 : ' + 'x'+str(rs1))
-                stats.covpt.append('rs1 : ' + 'x'+str(rs1))
-                value['rs1']['x'+str(rs1)] += 1
-            
-            if 'rs2' in value and 'x'+str(rs2) in value['rs2']:
-                if value['rs2']['x'+str(rs2)] == 0:
-                    stats.ucovpt.append('rs2 : ' + 'x'+str(rs2))
-                stats.covpt.append('rs2 : ' + 'x'+str(rs2))
-                value['rs2']['x'+str(rs2)] += 1
-            
-            if 'rd' in value and is_rd_valid and 'x'+str(rd) in value['rd']:
-                if value['rd']['x'+str(rd)] == 0:
-                    stats.ucovpt.append('rd : ' + 'x'+str(rd))
-                stats.covpt.append('rd : ' + 'x'+str(rd))
-                value['rd']['x'+str(rd)] += 1
-            
-            if 'rs1' in value and 'f'+str(rs1) in value['rs1']:
-                if value['rs1']['f'+str(rs1)] == 0:
-                    stats.ucovpt.append('rs1 : ' + 'f'+str(rs1))
-                stats.covpt.append('rs1 : ' + 'f'+str(rs1))
-                value['rs1']['f'+str(rs1)] += 1
-            
-            if 'rs2' in value and 'f'+str(rs2) in value['rs2']:
-                if value['rs2']['f'+str(rs2)] == 0:
-                    stats.ucovpt.append('rs2 : ' + 'f'+str(rs2))
-                stats.covpt.append('rs2 : ' + 'f'+str(rs2))
-                value['rs2']['f'+str(rs2)] += 1
-            
-            if 'rs3' in value and 'f'+str(rs3) in value['rs3']:
-                if value['rs3']['f'+str(rs3)] == 0:
-                    stats.ucovpt.append('rs3 : ' + 'f'+str(rs3))
-                stats.covpt.append('rs3 : ' + 'f'+str(rs3))
-                value['rs3']['f'+str(rs3)] += 1
-            
-            if 'rd' in value and is_rd_valid and 'f'+str(rd) in value['rd']:
-                if value['rd']['f'+str(rd)] == 0:
-                    stats.ucovpt.append('rd : ' + 'f'+str(rd))
-                stats.covpt.append('rd : ' + 'f'+str(rd))
-                value['rd']['f'+str(rd)] += 1
-            if 'op_comb' in value and len(value['op_comb']) != 0 :
-                for coverpoints in value['op_comb']:
-                    if eval(coverpoints):
-                        if cgf[cov_labels]['op_comb'][coverpoints] == 0:
-                            stats.ucovpt.append(str(coverpoints))
-                        stats.covpt.append(str(coverpoints))
-                        cgf[cov_labels]['op_comb'][coverpoints] += 1
-            
-            if 'val_comb' in value and len(value['val_comb']) != 0:
-                if instr.instr_name in ['fadd.s',"fsub.s","fmul.s","fdiv.s","fmax.s","fmin.s","feq.s","flt.s","fle.s","fsgnj.s","fsgnjn.s","fsgnjx.s"]:
-                        val_key = fmt.extract_fields(32, rs1_val, str(1))
-                        val_key+= " and "
-                        val_key+= fmt.extract_fields(32, rs2_val, str(2))
-                        val_key+= " and "
-                        val_key+= 'rm == '+ str(rm_val)
-                        l=[0]
-                        l[0] = val_key
-                        val_key = l
-                        if(val_key[0] in cgf[cov_labels]['val_comb']):
-                            if cgf[cov_labels]['val_comb'][val_key[0]] == 0:
-                                stats.ucovpt.append(str(val_key[0]))
-                            stats.covpt.append(str(val_key[0]))
-                            cgf[cov_labels]['val_comb'][val_key[0]] += 1
-                elif instr.instr_name in ["fsqrt.s","fmv.x.w","fmv.w.x","fcvt.wu.s","fcvt.s.wu","fcvt.w.s","fcvt.s.w","fclass.s"]:
-                        val_key = fmt.extract_fields(32, rs1_val, str(1))
-                        val_key+= " and "
-                        val_key+= 'rm == '+ str(rm_val)
-                        l=[0]
-                        l[0] = val_key
-                        val_key = l
-                        if(val_key[0] in cgf[cov_labels]['val_comb']):
-                            if cgf[cov_labels]['val_comb'][val_key[0]] == 0:
-                                stats.ucovpt.append(str(val_key[0]))
-                            stats.covpt.append(str(val_key[0]))
-                            cgf[cov_labels]['val_comb'][val_key[0]] += 1
-                elif instr.instr_name in ["fmadd.s","fmsub.s","fnmadd.s","fnmsub.s"]:
-                        val_key = fmt.extract_fields(32, rs1_val, str(1))
-                        val_key+= " and "
-                        val_key+= fmt.extract_fields(32, rs2_val, str(2))
-                        val_key+= " and "
-                        val_key+= fmt.extract_fields(32, rs3_val, str(3))
-                        val_key+= " and "
-                        val_key+= 'rm == '+ str(rm_val)
-                        l=[0]
-                        l[0] = val_key
-                        val_key = l
-                        if(val_key[0] in cgf[cov_labels]['val_comb']):
-                            if cgf[cov_labels]['val_comb'][val_key[0]] == 0:
-                                stats.ucovpt.append(str(val_key[0]))
-                            stats.covpt.append(str(val_key[0]))
-                            cgf[cov_labels]['val_comb'][val_key[0]] += 1
-                else:
-                    lcls=locals().copy()
-                    if instr.is_rvp and "rs1" in value:
-                        op_width = 64 if instr.rs1_nregs == 2 else xlen
-                        simd_val_unpack(value['val_comb'], op_width, "rs1", rs1_val, lcls)
-                    if instr.is_rvp and "rs2" in value:
-                        op_width = 64 if instr.rs2_nregs == 2 else xlen
-                        simd_val_unpack(value['val_comb'], op_width, "rs2", rs2_val, lcls)
-                    for coverpoints in value['val_comb']:
-                        if eval(coverpoints, globals(), lcls):
-                            if cgf[cov_labels]['val_comb'][coverpoints] == 0:
-                                stats.ucovpt.append(str(coverpoints))
-                            stats.covpt.append(str(coverpoints))
-                            cgf[cov_labels]['val_comb'][coverpoints] += 1
-            
-            if 'abstract_comb' in value \
-                    and len(value['abstract_comb']) != 0 :
-                for coverpoints in value['abstract_comb']:
-                    if eval(coverpoints):
-                        if cgf[cov_labels]['abstract_comb'][coverpoints] == 0:
-                            stats.ucovpt.append(str(coverpoints))
-                        stats.covpt.append(str(coverpoints))
-                        cgf[cov_labels]['abstract_comb'][coverpoints] +=1
-            if 'csr_comb' in value and len(value['csr_comb']) != 0:
-                for coverpoints in value['csr_comb']:
-                    if eval(coverpoints, {"__builtins__":None}, local_dict):
-                        if cgf[cov_labels]['csr_comb'][coverpoints] == 0:
-                            stats.ucovpt.append(str(coverpoints))
-                        stats.covpt.append(str(coverpoints))
-                        cgf[cov_labels]['csr_comb'][coverpoints] += 1
-        
-        elif 'opcode' not in value:
+                        if value['opcode'][instr.instr_name] == 0:
+                            stats.ucovpt.append('opcode : ' + instr.instr_name)
+                        stats.covpt.append('opcode : ' + instr.instr_name)
+                        value['opcode'][instr.instr_name] += 1
+                        if 'rs1' in value and 'x'+str(rs1) in value['rs1']:
+                            if value['rs1']['x'+str(rs1)] == 0:
+                                stats.ucovpt.append('rs1 : ' + 'x'+str(rs1))
+                            stats.covpt.append('rs1 : ' + 'x'+str(rs1))
+                            value['rs1']['x'+str(rs1)] += 1
+                        if 'rs2' in value and 'x'+str(rs2) in value['rs2']:
+                            if value['rs2']['x'+str(rs2)] == 0:
+                                stats.ucovpt.append('rs2 : ' + 'x'+str(rs2))
+                            stats.covpt.append('rs2 : ' + 'x'+str(rs2))
+                            value['rs2']['x'+str(rs2)] += 1
+                        if 'rd' in value and is_rd_valid and 'x'+str(rd) in value['rd']:
+                            if value['rd']['x'+str(rd)] == 0:
+                                stats.ucovpt.append('rd : ' + 'x'+str(rd))
+                            stats.covpt.append('rd : ' + 'x'+str(rd))
+                            value['rd']['x'+str(rd)] += 1
+
+                        if 'rs1' in value and 'f'+str(rs1) in value['rs1']:
+                            if value['rs1']['f'+str(rs1)] == 0:
+                                stats.ucovpt.append('rs1 : ' + 'f'+str(rs1))
+                            stats.covpt.append('rs1 : ' + 'f'+str(rs1))
+                            value['rs1']['f'+str(rs1)] += 1
+                        if 'rs2' in value and 'f'+str(rs2) in value['rs2']:
+                            if value['rs2']['f'+str(rs2)] == 0:
+                                stats.ucovpt.append('rs2 : ' + 'f'+str(rs2))
+                            stats.covpt.append('rs2 : ' + 'f'+str(rs2))
+                            value['rs2']['f'+str(rs2)] += 1
+                        if 'rs3' in value and 'f'+str(rs3) in value['rs3']:
+                            if value['rs3']['f'+str(rs3)] == 0:
+                                stats.ucovpt.append('rs3 : ' + 'f'+str(rs3))
+                            stats.covpt.append('rs3 : ' + 'f'+str(rs3))
+                            value['rs3']['f'+str(rs3)] += 1
+                        if 'rd' in value and is_rd_valid and 'f'+str(rd) in value['rd']:
+                            if value['rd']['f'+str(rd)] == 0:
+                                stats.ucovpt.append('rd : ' + 'f'+str(rd))
+                            stats.covpt.append('rd : ' + 'f'+str(rd))
+                            value['rd']['f'+str(rd)] += 1
+
+                        if 'op_comb' in value and len(value['op_comb']) != 0 :
+                            for coverpoints in value['op_comb']:
+                                if eval(coverpoints):
+                                    if cgf[cov_labels]['op_comb'][coverpoints] == 0:
+                                        stats.ucovpt.append(str(coverpoints))
+                                    stats.covpt.append(str(coverpoints))
+                                    cgf[cov_labels]['op_comb'][coverpoints] += 1
+                        if 'val_comb' in value and len(value['val_comb']) != 0:
+                            if instr.instr_name in ['fadd.s',"fsub.s","fmul.s","fdiv.s","fmax.s","fmin.s","feq.s","flt.s","fle.s","fsgnj.s","fsgnjn.s","fsgnjx.s"]:
+                                    val_key = fmt.extract_fields(32, rs1_val, str(1))
+                                    val_key+= " and "
+                                    val_key+= fmt.extract_fields(32, rs2_val, str(2))
+                                    val_key+= " and "
+                                    val_key+= 'rm == '+ str(rm_val)
+                                    l=[0]
+                                    l[0] = val_key
+                                    val_key = l
+                                    if(val_key[0] in cgf[cov_labels]['val_comb']):
+                                        if cgf[cov_labels]['val_comb'][val_key[0]] == 0:
+                                            stats.ucovpt.append(str(val_key[0]))
+                                        stats.covpt.append(str(val_key[0]))
+                                        cgf[cov_labels]['val_comb'][val_key[0]] += 1
+                            elif instr.instr_name in ["fsqrt.s","fmv.x.w","fmv.w.x","fcvt.wu.s","fcvt.s.wu","fcvt.w.s","fcvt.s.w","fclass.s"]:
+                                    val_key = fmt.extract_fields(32, rs1_val, str(1))
+                                    val_key+= " and "
+                                    val_key+= 'rm == '+ str(rm_val)
+                                    l=[0]
+                                    l[0] = val_key
+                                    val_key = l
+                                    if(val_key[0] in cgf[cov_labels]['val_comb']):
+                                        if cgf[cov_labels]['val_comb'][val_key[0]] == 0:
+                                            stats.ucovpt.append(str(val_key[0]))
+                                        stats.covpt.append(str(val_key[0]))
+                                        cgf[cov_labels]['val_comb'][val_key[0]] += 1
+                            elif instr.instr_name in ["fmadd.s","fmsub.s","fnmadd.s","fnmsub.s"]:
+                                    val_key = fmt.extract_fields(32, rs1_val, str(1))
+                                    val_key+= " and "
+                                    val_key+= fmt.extract_fields(32, rs2_val, str(2))
+                                    val_key+= " and "
+                                    val_key+= fmt.extract_fields(32, rs3_val, str(3))
+                                    val_key+= " and "
+                                    val_key+= 'rm == '+ str(rm_val)
+                                    l=[0]
+                                    l[0] = val_key
+                                    val_key = l
+                                    if(val_key[0] in cgf[cov_labels]['val_comb']):
+                                        if cgf[cov_labels]['val_comb'][val_key[0]] == 0:
+                                            stats.ucovpt.append(str(val_key[0]))
+                                        stats.covpt.append(str(val_key[0]))
+                                        cgf[cov_labels]['val_comb'][val_key[0]] += 1
+                            else:
+                                lcls=locals().copy()
+                                if instr.is_rvp and "rs1" in value:
+                                    op_width = 64 if instr.rs1_nregs == 2 else xlen
+                                    simd_val_unpack(value['val_comb'], op_width, "rs1", rs1_val, lcls)
+                                if instr.is_rvp and "rs2" in value:
+                                    op_width = 64 if instr.rs2_nregs == 2 else xlen
+                                    simd_val_unpack(value['val_comb'], op_width, "rs2", rs2_val, lcls)
+                                for coverpoints in value['val_comb']:
+                                    if eval(coverpoints, globals(), lcls):
+                                        if cgf[cov_labels]['val_comb'][coverpoints] == 0:
+                                            stats.ucovpt.append(str(coverpoints))
+                                        stats.covpt.append(str(coverpoints))
+                                        cgf[cov_labels]['val_comb'][coverpoints] += 1
+                        if 'abstract_comb' in value \
+                                and len(value['abstract_comb']) != 0 :
+                            for coverpoints in value['abstract_comb']:
+                                if eval(coverpoints):
+                                    if cgf[cov_labels]['abstract_comb'][coverpoints] == 0:
+                                        stats.ucovpt.append(str(coverpoints))
+                                    stats.covpt.append(str(coverpoints))
+                                    cgf[cov_labels]['abstract_comb'][coverpoints] += 1
+
+                        if 'csr_comb' in value and len(value['csr_comb']) != 0:
+                            for coverpoints in value['csr_comb']:
+                                if eval(coverpoints, {"__builtins__":None}, local_dict):
+                                    if cgf[cov_labels]['csr_comb'][coverpoints] == 0:
+                                        stats.ucovpt.append(str(coverpoints))
+                                    stats.covpt.append(str(coverpoints))
+                                    cgf[cov_labels]['csr_comb'][coverpoints] += 1
+                elif 'opcode' not in value:
                     if 'csr_comb' in value and len(value['csr_comb']) != 0:
                         for coverpoints in value['csr_comb']:
                             if eval(coverpoints, {"__builtins__":None}, local_dict):
@@ -815,38 +832,16 @@ def compute_per_line(instr, cgf, xlen, addr_pairs,  sig_addrs, no_count, procs):
                                     stats.ucovpt.append(str(coverpoints))
                                 stats.covpt.append(str(coverpoints))
                                 cgf[cov_labels]['csr_comb'][coverpoints] += 1
-
-    if enable:
-        if cgf.items():
-            cov_labels = list(cgf.keys())
-            try:
-                cov_labels.remove('datasets')
-            except ValueError:
-                pass
-            n = len(cov_labels)
-            process_pool = mp.Pool(processes=procs)
-            
-            # partition cover labels according to number of processors to be spawned
-            partitioned_chunks = [cov_labels[i:i + procs] for i in range(0, n, procs)]
-            
-            for labels in partitioned_chunks: 
-                process_pool.starmap_async(update_covpt, labels)
-            process_pool.close()
-            process_pool.join()
-        
         if stats.covpt:
             if mnemonic is not None :
                 stats.code_seq.append('[' + str(hex(instr.instr_addr)) + ']:' + mnemonic)
             else:
                 stats.code_seq.append('[' + str(hex(instr.instr_addr)) + ']:' + instr.instr_name)
-        
         if stats.ucovpt:
             if mnemonic is not None :
                 stats.ucode_seq.append('[' + str(hex(instr.instr_addr)) + ']:' + mnemonic)
             else:
-                stats.ucode_seq.append('[' + str(hex(instr.instr_addr)) + ']:' + instr.instr_name) 
-
-        
+                stats.ucode_seq.append('[' + str(hex(instr.instr_addr)) + ']:' + instr.instr_name)
 
     if instr.instr_name in ['sh','sb','sw','sd','c.sw','c.sd','c.swsp','c.sdsp'] and sig_addrs:
         store_address = rs1_val + imm_val
@@ -858,15 +853,9 @@ def compute_per_line(instr, cgf, xlen, addr_pairs,  sig_addrs, no_count, procs):
                 stats.cov_pt_sig += stats.covpt
                 if result_count <= 0:
                     if stats.ucovpt:
-                        
-                        # Signature update
-
                         stats.stat1.append((store_address, store_val, stats.ucovpt, stats.ucode_seq))
                         stats.last_meta = [store_address, store_val, stats.ucovpt, stats.ucode_seq]
                         stats.ucovpt = []
-
-                        # Delete node
-
                     elif stats.covpt:
                         _log = 'Op without unique coverpoint updates Signature\n'
                         _log += ' -- Code Sequence:\n'
@@ -878,9 +867,6 @@ def compute_per_line(instr, cgf, xlen, addr_pairs,  sig_addrs, no_count, procs):
                         for c in stats.covpt:
                             _log += '      - ' + str(c) + '\n'
                         logger.warn(_log)
-
-                        # Signature update
-
                         stats.stat2.append(_log + '\n\n')
                         stats.last_meta = [store_address, store_val, stats.covpt, stats.code_seq]
                     else:
@@ -897,8 +883,6 @@ def compute_per_line(instr, cgf, xlen, addr_pairs,  sig_addrs, no_count, procs):
                     stats.code_seq = []
                     stats.ucode_seq = []
 
-
-
     if commitvalue is not None:
         if rd_type == 'x':
             arch_state.x_rf[int(commitvalue[1])] =  str(commitvalue[2][2:])
@@ -911,17 +895,391 @@ def compute_per_line(instr, cgf, xlen, addr_pairs,  sig_addrs, no_count, procs):
             if(commits[0]=="CSR"):
                 csr_regfile[commits[1]] = str(commits[2][2:])
 
-
     return cgf
 
+
+def new_compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, addr_pairs, sig_addrs, stats, arch_state, csr_regfile, result_count):
+    '''
+    This function checks if the current instruction under scrutiny matches a
+    particular coverpoint of interest. If so, it updates the coverpoints and
+    return the same.
+
+    :param instr: an instructionObject of the single instruction currently parsed
+    :param cgf: a cgf against which coverpoints need to be checked for.
+    :param xlen: Max xlen of the trace
+    :param addr_pairs: pairs of start and end addresses for which the coverage needs to be updated
+
+    :type instr: :class:`instructionObject`
+    :type cgf: dict
+    :type xlen: int
+    :type addr_pairs: (int, int)
+    '''
+
+    while (event.is_set() == False) or (queue.empty() == False):
+        if queue.empty() is False:
+            
+            instr = queue.get_nowait()
+            
+            mnemonic = instr.mnemonic
+            commitvalue = instr.reg_commit
+
+            # assign default values to operands
+            rs1 = 0
+            rs2 = 0
+            rs3 = 0
+            rd  = 0
+            rs1_type = 'x'
+            rs2_type = 'x'
+            rs3_type = 'f'
+            rd_type = 'x'
+
+            csr_addr = 0
+
+            # create signed/unsigned conversion params
+            if xlen == 32:
+
+                unsgn_sz = '>I'
+                sgn_sz = '>i'
+            else:
+                unsgn_sz = '>Q'
+                sgn_sz = '>q'
+            # if instruction is empty then return
+            if instr is None:
+
+                return cgf
+            # check if instruction lies within the valid region of interest
+            if addr_pairs:
+
+                if any([instr.instr_addr >= saddr and instr.instr_addr < eaddr for saddr,eaddr in addr_pairs]):
+                    enable = True
+                else:
+                    enable = False
+            else:
+                enable=True
+            # capture the operands and their values from the regfile
+            if instr.rs1 is not None:
+
+                rs1 = instr.rs1[0]
+                rs1_type = instr.rs1[1]
+            if instr.rs2 is not None:
+                rs2 = instr.rs2[0]
+                rs2_type = instr.rs2[1]
+            if instr.rs3 is not None:
+                rs3 = instr.rs3[0]
+                rs3_type = instr.rs3[1]
+            if instr.rd is not None:
+                rd = instr.rd[0]
+
+                is_rd_valid = True
+                rd_type = instr.rd[1]
+            else:
+                is_rd_valid = False
+            if instr.imm is not None:
+                imm_val = instr.imm
+
+            if instr.shamt is not None:
+                imm_val = instr.shamt
+            # special value conversion based on signed/unsigned operations
+            if instr.instr_name in unsgn_rs1:
+
+                rs1_val = struct.unpack(unsgn_sz, bytes.fromhex(arch_state.x_rf[rs1]))[0]
+            elif instr.is_rvp:
+                rs1_val = struct.unpack(unsgn_sz, bytes.fromhex(arch_state.x_rf[rs1]))[0]
+                if instr.rs1_nregs == 2:
+                    rs1_hi_val = struct.unpack(unsgn_sz, bytes.fromhex(arch_state.x_rf[rs1+1]))[0]
+                    rs1_val = (rs1_hi_val << 32) | rs1_val
+            elif rs1_type == 'x':
+                rs1_val = struct.unpack(sgn_sz, bytes.fromhex(arch_state.x_rf[rs1]))[0]
+                if instr.instr_name in ["fmv.w.x"]:
+                    rs1_val = '0x' + (arch_state.x_rf[rs1]).lower()
+            elif rs1_type == 'f':
+                rs1_val = struct.unpack(sgn_sz, bytes.fromhex(arch_state.f_rf[rs1]))[0]
+                if instr.instr_name in ["fadd.s","fsub.s","fmul.s","fdiv.s","fsqrt.s","fmadd.s","fmsub.s","fnmadd.s","fnmsub.s","fmax.s","fmin.s","feq.s","flt.s","fle.s","fmv.x.w","fmv.w.x","fcvt.wu.s","fcvt.s.wu","fcvt.w.s","fcvt.s.w","fsgnj.s","fsgnjn.s","fsgnjx.s","fclass.s"]:
+                    rs1_val = '0x' + (arch_state.f_rf[rs1]).lower()
+            if instr.instr_name in unsgn_rs2:
+                rs2_val = struct.unpack(unsgn_sz, bytes.fromhex(arch_state.x_rf[rs2]))[0]
+
+            elif instr.is_rvp:
+                rs2_val = struct.unpack(unsgn_sz, bytes.fromhex(arch_state.x_rf[rs2]))[0]
+                if instr.rs2_nregs == 2:
+                    rs2_hi_val = struct.unpack(unsgn_sz, bytes.fromhex(arch_state.x_rf[rs2+1]))[0]
+                    rs2_val = (rs2_hi_val << 32) | rs2_val
+            elif rs2_type == 'x':
+                rs2_val = struct.unpack(sgn_sz, bytes.fromhex(arch_state.x_rf[rs2]))[0]
+            elif rs2_type == 'f':
+                rs2_val = struct.unpack(sgn_sz, bytes.fromhex(arch_state.f_rf[rs2]))[0]
+                if instr.instr_name in ["fadd.s","fsub.s","fmul.s","fdiv.s","fmadd.s","fmsub.s","fnmadd.s","fnmsub.s","fmax.s","fmin.s","feq.s","flt.s","fle.s","fsgnj.s","fsgnjn.s","fsgnjx.s"]:
+                    rs2_val = '0x' + (arch_state.f_rf[rs2]).lower()
+
+            sig_update = False
+            if instr.instr_name in ['sh','sb','sw','sd','c.sw','c.sd','c.swsp','c.sdsp'] and sig_addrs:
+                store_address = rs1_val + imm_val
+                for start, end in sig_addrs:
+                    if store_address >= start and store_address <= end:
+                        sig_update = True
+                        break
+
+            if sig_update: # writing result operands of last non-store instruction to the signature region
+                result_count = result_count - 1
+            else:
+                result_count = instr.rd_nregs
+
+            if instr.instr_name in ["fmadd.s","fmsub.s","fnmadd.s","fnmsub.s"]:
+                rs3_val = '0x' + (arch_state.f_rf[rs3]).lower()
+
+            if instr.instr_name in ['csrrwi']:
+                arch_state.fcsr = instr.zimm
+
+            if instr.instr_name in ["fadd.s","fsub.s","fmul.s","fdiv.s","fsqrt.s","fmadd.s","fmsub.s","fnmadd.s","fnmsub.s","fmax.s","fmin.s","feq.s","flt.s","fle.s","fmv.x.w","fmv.w.x","fcvt.wu.s","fcvt.s.wu","fcvt.w.s","fcvt.s.w","fsgnj.s","fsgnjn.s","fsgnjx.s","fclass.s"]:
+                rm = instr.rm
+                if(rm==7 or rm==None):
+                    rm_val = arch_state.fcsr
+                else:
+                    rm_val = rm
+
+            arch_state.pc = instr.instr_addr
+
+            # the ea_align variable is used by the eval statements of the
+            # coverpoints for conditional ops and memory ops
+            if instr.instr_name in ['jal','bge','bgeu','blt','bltu','beq','bne']:
+                ea_align = (instr.instr_addr+(imm_val<<1)) % 4
+
+            if instr.instr_name == "jalr":
+                ea_align = (rs1_val + imm_val) % 4
+
+            if instr.instr_name in ['sw','sh','sb','lw','lhu','lh','lb','lbu','lwu','flw','fsw']:
+                ea_align = (rs1_val + imm_val) % 4
+            if instr.instr_name in ['ld','sd']:
+                ea_align = (rs1_val + imm_val) % 8
+
+            local_dict={}
+            for i in csr_regfile.csr_regs:
+                local_dict[i] = int(csr_regfile[i],16)
+
+            local_dict['xlen'] = xlen
+
+            if enable :
+                for cov_labels,value in cgf.items():
+                    if cov_labels != 'datasets':
+                        if 'opcode' in value:
+                            if instr.instr_name in value['opcode']:
+                                if stats.code_seq:
+                                    #logger.error('Found a coverpoint without sign Upd ' + str(stats.code_seq))
+                                    stats.stat3.append('\n'.join(stats.code_seq))
+                                    stats.code_seq = []
+                                    stats.covpt = []
+                                    stats.ucovpt = []
+                                    stats.ucode_seq = []
+
+                                if value['opcode'][instr.instr_name] == 0:
+                                    stats.ucovpt.append('opcode : ' + instr.instr_name)
+                                stats.covpt.append('opcode : ' + instr.instr_name)
+                                value['opcode'][instr.instr_name] += 1
+                                if 'rs1' in value and 'x'+str(rs1) in value['rs1']:
+                                    if value['rs1']['x'+str(rs1)] == 0:
+                                        stats.ucovpt.append('rs1 : ' + 'x'+str(rs1))
+                                    stats.covpt.append('rs1 : ' + 'x'+str(rs1))
+                                    value['rs1']['x'+str(rs1)] += 1
+                                if 'rs2' in value and 'x'+str(rs2) in value['rs2']:
+                                    if value['rs2']['x'+str(rs2)] == 0:
+                                        stats.ucovpt.append('rs2 : ' + 'x'+str(rs2))
+                                    stats.covpt.append('rs2 : ' + 'x'+str(rs2))
+                                    value['rs2']['x'+str(rs2)] += 1
+                                if 'rd' in value and is_rd_valid and 'x'+str(rd) in value['rd']:
+                                    if value['rd']['x'+str(rd)] == 0:
+                                        stats.ucovpt.append('rd : ' + 'x'+str(rd))
+                                    stats.covpt.append('rd : ' + 'x'+str(rd))
+                                    value['rd']['x'+str(rd)] += 1
+
+                                if 'rs1' in value and 'f'+str(rs1) in value['rs1']:
+                                    if value['rs1']['f'+str(rs1)] == 0:
+                                        stats.ucovpt.append('rs1 : ' + 'f'+str(rs1))
+                                    stats.covpt.append('rs1 : ' + 'f'+str(rs1))
+                                    value['rs1']['f'+str(rs1)] += 1
+                                if 'rs2' in value and 'f'+str(rs2) in value['rs2']:
+                                    if value['rs2']['f'+str(rs2)] == 0:
+                                        stats.ucovpt.append('rs2 : ' + 'f'+str(rs2))
+                                    stats.covpt.append('rs2 : ' + 'f'+str(rs2))
+                                    value['rs2']['f'+str(rs2)] += 1
+                                if 'rs3' in value and 'f'+str(rs3) in value['rs3']:
+                                    if value['rs3']['f'+str(rs3)] == 0:
+                                        stats.ucovpt.append('rs3 : ' + 'f'+str(rs3))
+                                    stats.covpt.append('rs3 : ' + 'f'+str(rs3))
+                                    value['rs3']['f'+str(rs3)] += 1
+                                if 'rd' in value and is_rd_valid and 'f'+str(rd) in value['rd']:
+                                    if value['rd']['f'+str(rd)] == 0:
+                                        stats.ucovpt.append('rd : ' + 'f'+str(rd))
+                                    stats.covpt.append('rd : ' + 'f'+str(rd))
+                                    value['rd']['f'+str(rd)] += 1
+
+                                if 'op_comb' in value and len(value['op_comb']) != 0 :
+                                    for coverpoints in value['op_comb']:
+                                        if eval(coverpoints):
+                                            if cgf[cov_labels]['op_comb'][coverpoints] == 0:
+                                                stats.ucovpt.append(str(coverpoints))
+                                            stats.covpt.append(str(coverpoints))
+                                            cgf[cov_labels]['op_comb'][coverpoints] += 1
+                                if 'val_comb' in value and len(value['val_comb']) != 0:
+                                    if instr.instr_name in ['fadd.s',"fsub.s","fmul.s","fdiv.s","fmax.s","fmin.s","feq.s","flt.s","fle.s","fsgnj.s","fsgnjn.s","fsgnjx.s"]:
+                                            val_key = fmt.extract_fields(32, rs1_val, str(1))
+                                            val_key+= " and "
+                                            val_key+= fmt.extract_fields(32, rs2_val, str(2))
+                                            val_key+= " and "
+                                            val_key+= 'rm == '+ str(rm_val)
+                                            l=[0]
+                                            l[0] = val_key
+                                            val_key = l
+                                            if(val_key[0] in cgf[cov_labels]['val_comb']):
+                                                if cgf[cov_labels]['val_comb'][val_key[0]] == 0:
+                                                    stats.ucovpt.append(str(val_key[0]))
+                                                stats.covpt.append(str(val_key[0]))
+                                                cgf[cov_labels]['val_comb'][val_key[0]] += 1
+                                    elif instr.instr_name in ["fsqrt.s","fmv.x.w","fmv.w.x","fcvt.wu.s","fcvt.s.wu","fcvt.w.s","fcvt.s.w","fclass.s"]:
+                                            val_key = fmt.extract_fields(32, rs1_val, str(1))
+                                            val_key+= " and "
+                                            val_key+= 'rm == '+ str(rm_val)
+                                            l=[0]
+                                            l[0] = val_key
+                                            val_key = l
+                                            if(val_key[0] in cgf[cov_labels]['val_comb']):
+                                                if cgf[cov_labels]['val_comb'][val_key[0]] == 0:
+                                                    stats.ucovpt.append(str(val_key[0]))
+                                                stats.covpt.append(str(val_key[0]))
+                                                cgf[cov_labels]['val_comb'][val_key[0]] += 1
+                                    elif instr.instr_name in ["fmadd.s","fmsub.s","fnmadd.s","fnmsub.s"]:
+                                            val_key = fmt.extract_fields(32, rs1_val, str(1))
+                                            val_key+= " and "
+                                            val_key+= fmt.extract_fields(32, rs2_val, str(2))
+                                            val_key+= " and "
+                                            val_key+= fmt.extract_fields(32, rs3_val, str(3))
+                                            val_key+= " and "
+                                            val_key+= 'rm == '+ str(rm_val)
+                                            l=[0]
+                                            l[0] = val_key
+                                            val_key = l
+                                            if(val_key[0] in cgf[cov_labels]['val_comb']):
+                                                if cgf[cov_labels]['val_comb'][val_key[0]] == 0:
+                                                    stats.ucovpt.append(str(val_key[0]))
+                                                stats.covpt.append(str(val_key[0]))
+                                                cgf[cov_labels]['val_comb'][val_key[0]] += 1
+                                    else:
+                                        lcls=locals().copy()
+                                        if instr.is_rvp and "rs1" in value:
+                                            op_width = 64 if instr.rs1_nregs == 2 else xlen
+                                            simd_val_unpack(value['val_comb'], op_width, "rs1", rs1_val, lcls)
+                                        if instr.is_rvp and "rs2" in value:
+                                            op_width = 64 if instr.rs2_nregs == 2 else xlen
+                                            simd_val_unpack(value['val_comb'], op_width, "rs2", rs2_val, lcls)
+                                        for coverpoints in value['val_comb']:
+                                            if eval(coverpoints, globals(), lcls):
+                                                if cgf[cov_labels]['val_comb'][coverpoints] == 0:
+                                                    stats.ucovpt.append(str(coverpoints))
+                                                stats.covpt.append(str(coverpoints))
+                                                cgf[cov_labels]['val_comb'][coverpoints] += 1
+                                if 'abstract_comb' in value \
+                                        and len(value['abstract_comb']) != 0 :
+                                    for coverpoints in value['abstract_comb']:
+                                        if eval(coverpoints):
+                                            if cgf[cov_labels]['abstract_comb'][coverpoints] == 0:
+                                                stats.ucovpt.append(str(coverpoints))
+                                            stats.covpt.append(str(coverpoints))
+                                            cgf[cov_labels]['abstract_comb'][coverpoints] += 1
+
+                                if 'csr_comb' in value and len(value['csr_comb']) != 0:
+                                    for coverpoints in value['csr_comb']:
+                                        if eval(coverpoints, {"__builtins__":None}, local_dict):
+                                            if cgf[cov_labels]['csr_comb'][coverpoints] == 0:
+                                                stats.ucovpt.append(str(coverpoints))
+                                            stats.covpt.append(str(coverpoints))
+                                            cgf[cov_labels]['csr_comb'][coverpoints] += 1
+                        elif 'opcode' not in value:
+                            if 'csr_comb' in value and len(value['csr_comb']) != 0:
+                                for coverpoints in value['csr_comb']:
+                                    if eval(coverpoints, {"__builtins__":None}, local_dict):
+                                        if cgf[cov_labels]['csr_comb'][coverpoints] == 0:
+                                            stats.ucovpt.append(str(coverpoints))
+                                        stats.covpt.append(str(coverpoints))
+                                        cgf[cov_labels]['csr_comb'][coverpoints] += 1
+                if stats.covpt:
+                    if mnemonic is not None :
+                        stats.code_seq.append('[' + str(hex(instr.instr_addr)) + ']:' + mnemonic)
+                    else:
+                        stats.code_seq.append('[' + str(hex(instr.instr_addr)) + ']:' + instr.instr_name)
+                if stats.ucovpt:
+                    if mnemonic is not None :
+                        stats.ucode_seq.append('[' + str(hex(instr.instr_addr)) + ']:' + mnemonic)
+                    else:
+                        stats.ucode_seq.append('[' + str(hex(instr.instr_addr)) + ']:' + instr.instr_name)
+
+            if instr.instr_name in ['sh','sb','sw','sd','c.sw','c.sd','c.swsp','c.sdsp'] and sig_addrs:
+                store_address = rs1_val + imm_val
+                store_val = '0x'+arch_state.x_rf[rs2]
+                for start, end in sig_addrs:
+                    if store_address >= start and store_address <= end:
+                        logger.debug('Signature update : ' + str(hex(store_address)))
+                        stats.stat5.append((store_address, store_val, stats.ucovpt, stats.code_seq))
+                        stats.cov_pt_sig += stats.covpt
+                        if result_count <= 0:
+                            if stats.ucovpt:
+                                stats.stat1.append((store_address, store_val, stats.ucovpt, stats.ucode_seq))
+                                stats.last_meta = [store_address, store_val, stats.ucovpt, stats.ucode_seq]
+                                stats.ucovpt = []
+                            elif stats.covpt:
+                                _log = 'Op without unique coverpoint updates Signature\n'
+                                _log += ' -- Code Sequence:\n'
+                                for op in stats.code_seq:
+                                    _log += '      ' + op + '\n'
+                                _log += ' -- Signature Address: {0} Data: {1}\n'.format(
+                                        str(hex(store_address)), store_val)
+                                _log += ' -- Redundant Coverpoints hit by the op\n'
+                                for c in stats.covpt:
+                                    _log += '      - ' + str(c) + '\n'
+                                logger.warn(_log)
+                                stats.stat2.append(_log + '\n\n')
+                                stats.last_meta = [store_address, store_val, stats.covpt, stats.code_seq]
+                            else:
+                                _log = 'Last Coverpoint : ' + str(stats.last_meta[2]) + '\n'
+                                _log += 'Last Code Sequence : \n\t-' + '\n\t-'.join(stats.last_meta[3]) + '\n'
+                                _log +='Current Store : [{0}] : {1} -- Store: [{2}]:{3}\n'.format(\
+                                    str(hex(instr.instr_addr)), mnemonic,
+                                    str(hex(store_address)),
+                                    store_val)
+                                logger.error(_log)
+                                stats.stat4.append(_log + '\n\n')
+
+                            stats.covpt = []
+                            stats.code_seq = []
+                            stats.ucode_seq = []
+
+            if commitvalue is not None:
+                if rd_type == 'x':
+                    arch_state.x_rf[int(commitvalue[1])] =  str(commitvalue[2][2:])
+                elif rd_type == 'f':
+                    arch_state.f_rf[int(commitvalue[1])] =  str(commitvalue[2][2:])
+
+            csr_commit = instr.csr_commit
+            if csr_commit is not None:
+                for commits in csr_commit:
+                    if(commits[0]=="CSR"):
+                        csr_regfile[commits[1]] = str(commits[2][2:])
+    else:
+        cgf_queue.put(cgf)
+        stats_queue.put(stats)
+        cgf_queue.close()
+        stats_queue.close()
+        print('Going back!')
+        
+
 def compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xlen, addr_pairs
-        , dump, cov_labels, sig_addrs, window_size, no_count, procs):
+        , dump, cov_labels, sig_addrs, window_size, no_count, procs = 1):
     '''Compute the Coverage'''
+
     global arch_state
     global csr_regfile
     global stats
     global cross_cover_queue
     global result_count
+
     temp = cgf.copy()
     if cov_labels:
         for groups in cgf:
@@ -977,20 +1335,135 @@ def compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xle
     decoder.setup(arch="rv"+str(xlen))
 
     iterator = iter(parser.__iter__()[0])
-    rcgf = cgf
-    for instrObj_temp in iterator:
-        instr = instrObj_temp.instr
-        if instr is None:
-            continue
-        instrObj = (decoder.decode(instrObj_temp = instrObj_temp))[0]
-        logger.debug(instrObj)
-        cross_cover_queue.append(instrObj)
-        if(len(cross_cover_queue)>=window_size):
-            for (label,coverpt) in obj_dict.keys():
-                obj_dict[(label,coverpt)].process(cross_cover_queue, window_size,addr_pairs)
-            cross_cover_queue.pop(0)
-        rcgf = compute_per_line(instrObj, rcgf, xlen,
-                        addr_pairs, sig_addrs, no_count, procs)
+    
+    
+    if procs > 1:
+        
+        start = time.time()
+
+        # If number of processors to be spawned is more than that available
+        available_cores = mp.cpu_count()
+        if procs > available_cores:
+            procs = available_cores - 1
+
+        # Partiton cgf to chunks
+        chunk_len = math.ceil(len(cgf) / procs)
+        chunks = [{k:cgf[k] for k in islice(iter(cgf), chunk_len)} for i in range(0, len(cgf), chunk_len)]
+        
+        queue_list = []
+        process_list = []
+        event_list = []
+
+        cgf_queue_list = []
+        stats_queue_list = []
+
+        #Initialize processes and queues
+        for i in range(len(chunks)):
+            queue_list.append(mp.Queue())
+            cgf_queue_list.append(mp.Queue())
+            stats_queue_list.append(mp.Queue())
+            event_list.append(mp.Event())
+            process_list.append(
+                            mp.Process(target=new_compute_per_line, 
+                                    args=(queue_list[i], event_list[i], cgf_queue_list[i], stats_queue_list[i],
+                                        chunks[i], xlen, addr_pairs, sig_addrs,
+                                        stats, 
+                                        arch_state, 
+                                        csr_regfile,
+                                        result_count
+                                        )
+                                )
+                            )
+        end = time.time()
+        print(f'Setup time for {procs} processes: {end-start}')
+
+        #Start processes
+        for each in process_list:
+            each.start()
+
+        queue_time = 0
+        for instrObj_temp in iterator:
+            instr = instrObj_temp.instr
+            if instr is None:
+                continue
+            instrObj = (decoder.decode(instrObj_temp = instrObj_temp))[0]
+            
+            start_queue = time.time()
+            # Pass instrObjs to queue
+            for each in queue_list:
+                each.put_nowait(instrObj)
+            end_queue = time.time()
+            queue_time = queue_time + (end_queue - start_queue)
+
+            logger.debug(instrObj)
+            cross_cover_queue.append(instrObj)
+            if(len(cross_cover_queue)>=window_size):
+                for (label,coverpt) in obj_dict.keys():
+                    obj_dict[(label,coverpt)].process(cross_cover_queue, window_size,addr_pairs)
+                cross_cover_queue.pop(0)
+        end = time.time()
+        print(f'Time elapsed for loop: {end - start}')
+        print(f'Total time elapsed for queues: {queue_time}')
+
+        # Signal each processes that instruction list is over
+        for each in event_list:
+            each.set()
+        
+        # Close all queues
+        for each in queue_list:
+            each.close()
+            each.join_thread()
+
+        # Get the renewed cgfs
+        cgf_list = []
+        for each in cgf_queue_list:
+            cgf_list.append(each.get())
+            each.close()
+            each.join_thread()
+
+        # Get each stats
+        stats_list = []
+        for each in stats_queue_list:
+            stats_list.append(each.get())
+            each.close()
+            each.join_thread()
+
+        # Join all processes
+        for each in process_list:
+            each.join()
+
+        end = time.time()
+        print(f'With multiple processes: {end - start}')
+
+        # Merge stats
+        for each in stats_list:
+            stats = stats + each
+
+        # Merge cgfs
+        rcgf = dict()
+        for d in cgf_list:
+            for key, val in d.items():
+                rcgf[key] = val
+    
+    else:
+        rcgf = cgf
+        start = time.time()
+        for instrObj_temp in iterator:
+            instr = instrObj_temp.instr
+            if instr is None:
+                continue
+            instrObj = (decoder.decode(instrObj_temp = instrObj_temp))[0]
+            logger.debug(instrObj)
+            cross_cover_queue.append(instrObj)
+            if(len(cross_cover_queue)>=window_size):
+                for (label,coverpt) in obj_dict.keys():
+                    obj_dict[(label,coverpt)].process(cross_cover_queue, window_size,addr_pairs)
+                cross_cover_queue.pop(0)
+            rcgf = compute_per_line(instrObj, rcgf, xlen,
+                            addr_pairs, sig_addrs)
+        
+        end = time.time()
+        print(f'With single process: {end-start}')
 
     ## Check for cross coverage for end instructions
     ## All metric is stored in objects of obj_dict

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -2,9 +2,6 @@
 # See LICENSE.incore for details
 # See LICENSE.iitm for details
 
-from itertools import islice
-import pprint
-import time
 import ruamel
 from ruamel.yaml import YAML
 import riscv_isac.utils as utils
@@ -22,6 +19,7 @@ import pluggy
 import riscv_isac.plugins as plugins
 from riscv_isac.plugins.specification import *
 import math
+from itertools import islice
 import multiprocessing as mp
 from collections.abc import MutableMapping
 
@@ -1093,19 +1091,16 @@ def compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xle
     #Start processes
     for each in process_list:
         each.start()
-    queue_time = 0
     for instrObj_temp in iterator:
         instr = instrObj_temp.instr
         if instr is None:
             continue
         instrObj = (decoder.decode(instrObj_temp = instrObj_temp))[0]
-        
-        start_queue = time.time()
+
         # Pass instrObjs to queue
         for each in queue_list:
             each.put_nowait(instrObj)
-        end_queue = time.time()
-        queue_time = queue_time + (end_queue - start_queue)
+
         logger.debug(instrObj)
         cross_cover_queue.append(instrObj)
         if(len(cross_cover_queue)>=window_size):

--- a/riscv_isac/isac.py
+++ b/riscv_isac/isac.py
@@ -6,7 +6,7 @@ import riscv_isac.coverage as cov
 from elftools.elf.elffile import ELFFile
 
 def isac(output_file,elf ,trace_file, window_size, cgf, parser_name, decoder_name, parser_path, decoder_path, detailed, test_labels,
-        sig_labels, dump, cov_labels, xlen, logging=False):
+        sig_labels, dump, cov_labels, xlen, no_count, logging=False):
     test_addr = []
     sig_addr = []
 
@@ -38,7 +38,7 @@ def isac(output_file,elf ,trace_file, window_size, cgf, parser_name, decoder_nam
                 sig_addr.append((start_address,end_address))
     else:
         test_name = trace_file.rsplit(',',1)[0]
-    rpt = cov.compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xlen, test_addr, dump, cov_labels, sig_addr, window_size)
+    rpt = cov.compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xlen, test_addr, dump, cov_labels, sig_addr, window_size, no_count)
     if output_file is not None and logging:
         logger.info('Coverage Report:')
         logger.info('\n\n' + rpt)

--- a/riscv_isac/isac.py
+++ b/riscv_isac/isac.py
@@ -6,7 +6,7 @@ import riscv_isac.coverage as cov
 from elftools.elf.elffile import ELFFile
 
 def isac(output_file,elf ,trace_file, window_size, cgf, parser_name, decoder_name, parser_path, decoder_path, detailed, test_labels,
-        sig_labels, dump, cov_labels, xlen, no_count, logging=False):
+        sig_labels, dump, cov_labels, xlen, no_count, procs, logging=False):
     test_addr = []
     sig_addr = []
 

--- a/riscv_isac/isac.py
+++ b/riscv_isac/isac.py
@@ -9,7 +9,6 @@ def isac(output_file,elf ,trace_file, window_size, cgf, parser_name, decoder_nam
         sig_labels, dump, cov_labels, xlen, no_count, procs, logging=False):
     test_addr = []
     sig_addr = []
-
     if parser_path:
         sys.path.append(parser_path)
     if decoder_path:
@@ -38,7 +37,7 @@ def isac(output_file,elf ,trace_file, window_size, cgf, parser_name, decoder_nam
                 sig_addr.append((start_address,end_address))
     else:
         test_name = trace_file.rsplit(',',1)[0]
-    rpt = cov.compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xlen, test_addr, dump, cov_labels, sig_addr, window_size, no_count)
+    rpt = cov.compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xlen, test_addr, dump, cov_labels, sig_addr, window_size, no_count, procs)
     if output_file is not None and logging:
         logger.info('Coverage Report:')
         logger.info('\n\n' + rpt)

--- a/riscv_isac/main.py
+++ b/riscv_isac/main.py
@@ -104,13 +104,20 @@ def cli(verbose):
         multiple=True,
         help = "Coverage labels to consider for this run."
 )
-@click.option('--xlen','-x',type=click.Choice(['32','64']),default='32',help="XLEN value for the ISA.")
+@click.option('--xlen','-x',
+        type=click.Choice(['32','64']),
+        default='32',
+        help="XLEN value for the ISA."
+)
+@click.option('--no-count',
+        is_flag = True,
+        help = "This option removes hit coverpoints during coverage computation"
+)
+
 def coverage(elf,trace_file, window_size, cgf_file, detailed,parser_name, decoder_name, parser_path, decoder_path,output_file, test_label,
-        sig_label, dump,cov_label, xlen):
+        sig_label, dump,cov_label, xlen, no_count):
     isac(output_file,elf,trace_file, window_size, expand_cgf(cgf_file,int(xlen)), parser_name, decoder_name, parser_path, decoder_path, detailed, test_label,
-            sig_label, dump, cov_label, int(xlen))
-
-
+            sig_label, dump, cov_label, int(xlen), no_count)
 
 @cli.command(help = "Merge given coverage files.")
 @click.argument(
@@ -169,5 +176,4 @@ def normalize(cgf_file,output_file,xlen):
     logger.info("Writing normalized CGF to "+str(output_file))
     with open(output_file,"w") as outfile:
         utils.dump_yaml(expand_cgf(cgf_file,int(xlen)),outfile)
-
 

--- a/riscv_isac/main.py
+++ b/riscv_isac/main.py
@@ -113,11 +113,15 @@ def cli(verbose):
         is_flag = True,
         help = "This option removes hit coverpoints during coverage computation"
 )
+@click.option('--processes', '-p',
+        default = 1,
+        help = 'Set number of processes to calculate coverage'
+)
 
 def coverage(elf,trace_file, window_size, cgf_file, detailed,parser_name, decoder_name, parser_path, decoder_path,output_file, test_label,
-        sig_label, dump,cov_label, xlen, no_count):
+        sig_label, dump,cov_label, xlen, no_count, procs):
     isac(output_file,elf,trace_file, window_size, expand_cgf(cgf_file,int(xlen)), parser_name, decoder_name, parser_path, decoder_path, detailed, test_label,
-            sig_label, dump, cov_label, int(xlen), no_count)
+            sig_label, dump, cov_label, int(xlen), no_count. procs)
 
 @cli.command(help = "Merge given coverage files.")
 @click.argument(

--- a/riscv_isac/main.py
+++ b/riscv_isac/main.py
@@ -113,7 +113,7 @@ def cli(verbose):
         is_flag = True,
         help = "This option removes hit coverpoints during coverage computation"
 )
-@click.option('--processes', '-p',
+@click.option('--procs', '-p',
         default = 1,
         help = 'Set number of processes to calculate coverage'
 )
@@ -121,7 +121,7 @@ def cli(verbose):
 def coverage(elf,trace_file, window_size, cgf_file, detailed,parser_name, decoder_name, parser_path, decoder_path,output_file, test_label,
         sig_label, dump,cov_label, xlen, no_count, procs):
     isac(output_file,elf,trace_file, window_size, expand_cgf(cgf_file,int(xlen)), parser_name, decoder_name, parser_path, decoder_path, detailed, test_label,
-            sig_label, dump, cov_label, int(xlen), no_count. procs)
+            sig_label, dump, cov_label, int(xlen), no_count, procs)
 
 @cli.command(help = "Merge given coverage files.")
 @click.argument(
@@ -180,4 +180,3 @@ def normalize(cgf_file,output_file,xlen):
     logger.info("Writing normalized CGF to "+str(output_file))
     with open(output_file,"w") as outfile:
         utils.dump_yaml(expand_cgf(cgf_file,int(xlen)),outfile)
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.1
+current_version = 0.11.0
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.11.0
+current_version = 0.12.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = [ ]
 
 setup(
     name='riscv_isac',
-    version='0.11.0',
+    version='0.12.0',
     description="RISC-V ISAC",
     long_description=readme + '\n\n',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = [ ]
 
 setup(
     name='riscv_isac',
-    version='0.10.1',
+    version='0.11.0',
     description="RISC-V ISAC",
     long_description=readme + '\n\n',
     classifiers=[


### PR DESCRIPTION
This Pull request is related to issue mentioned in #27 
The PR involves the following feature additions:
- Parallelization of coverage computation. Number of processes to be spawned can be provided using `--procs` option in CLI. Default value is 1.
- Removal of hit coverpoints from working CGF dictionary. This feature can be enabled by using `--no-count` option in CLI. It is disabled by default.