### PR TITLE
Support for pseudoinstructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2022-05-02
+- Covergroup format revised.
+- Added support for Pseudoinstructions for coverage computation.
+
 ## [0.12.0] - 2022-04-15
 - Parallelized coverage computation.
 - Added feature to remove coverpoints when hit.

--- a/docs/source/cgf.rst
+++ b/docs/source/cgf.rst
@@ -12,7 +12,9 @@ Covergroup
 ==========
 A covergroup is a dictionary based on the following template. These dictionaries constitute the nodes in a cgf file. Each cover group contains the following type of coverpoints:
 
-* Opcode
+* Mnemonics
+* Base-op
+* Pseudo-op conditions
 * Register
 * Register Operand Combinations
 * Register/Immediate Value Combinations
@@ -22,16 +24,16 @@ A covergroup is a dictionary based on the following template. These dictionaries
 Template
 --------
 
-The template for defining a covergroup is as follows:
+The template for defining a non pseudo-op covergroup is as follows:
 
 .. code-block:: yaml
 
     <label>:
         config:
             - <config-str>
-        opcode:
-            <opcode-str>: 0
-            <opcode-str>: 0
+        mnemonics:
+            <mnemonics-str>: 0
+            <mnemonics-str>: 0
             ...
         rs1:
             <reg-str>: 0
@@ -64,7 +66,20 @@ The template for defining a covergroup is as follows:
             <crosscomb_str>:0
             <crosscomb_str>:0
            
+The template for defining a covergroup pertaining to a pseudo-op is as follows:
 
+.. code-block:: yaml
+
+    <label>:
+        config:
+            - <config-str>
+        mnemonics:
+            <mnemonics-str>: 0
+        base_op:
+            <base_op-str>
+        p_op_cond:
+            <p_op_cond-str>
+        ...
     
 Explanation
 -----------
@@ -84,13 +99,27 @@ A covergroup contains the following nodes:
 .. _RVTEST_CASE Condition Formating: https://riscof.readthedocs.io/en/latest/testformat.html?highlight=Macro#rvtest-case-condition-formating  
 .. _riscof: https://riscof.readthedocs.io/en/latest/index.html 
 
-* **opcode**
+* **mnemonics**
     *This node is mandatory for all covergroups except covergroups pertaining to CSR coverpoints (it's optional in this case).*
     
-    This node describes the *opcode coverpoints* necessary for the covergroup. Each *opcode* is treated as a valid coverpoint and the arguments of the corresponding instruction are used to update the rest of the coverpoint types.  
+    This node describes the *mnemonics coverpoints* necessary for the covergroup. Each mnemonic defined under *mnemonics* is treated as a valid coverpoint and the arguments of the corresponding instruction are used to update the rest of the coverpoint types.  
 
-        * **opcode-str**
-            A valid *opcode* in the RISCV Instruction Set.
+        * **mnemonics-str**
+            A valid instruction or pseudoinstruction *mnemonic* in the RISCV Instruction Set.
+
+* **base_op**
+    *If the instruction defined in mnemonics is a pseudo-op, *base_op* field can be used to provide its corresponding base instruction. Essentially, *base_op* can be used to provide an alternate definition to the instruction in *mnemonics*.
+
+    Note that when *base_op* node is defined, the *mnemonics* node should only hold the pseudoinstruction. To supply the conditions for which the *base_op* becomes the pseudoinstruction in *mnemonics*, *p_op_cond* node should be mandatorily used.
+
+        * **base_op-str**
+            The base instruction corresponding to the pseudoinstruction defined in *mnemonics*
+
+* **p_op_cond**
+    *This node is used to supply the requisite conditions for the *base_op* to be congruent to the pseudoinstruction in *mnemonics* node.
+
+        * **p_op_cond-str**
+            Conditions required for the base instruction to be congruent to the pseudoinstruction in *mnemonics*. Multiple conditions are joined using ``and``. For example, ``rs1 == x0 and imm == 3``
 
 * **rs1**
     *This node is optional.*

--- a/docs/source/pseudo_op_support.rst
+++ b/docs/source/pseudo_op_support.rst
@@ -1,0 +1,48 @@
+*********************************
+Pseudo-Ops Support for RISCV-ISAC
+*********************************
+
+Coverpoints are defined in a CGF file under the ``opcode`` node in the CGF. This is a misnomer as ISAC and CTG
+deals with mnemonics of the instruction rather than the actual encoding. In order to deal with mnemonics of pseudo-Ops, 
+and its congruent base instruction definition, changes are brought to the CGF format.
+
+Format
+######
+The ``opcode`` field is renamed to ``mnemonics``. To support pseudo-instructions two new fields ``base_op`` and ``p_op_cond``
+are added to the covergroups. The ``base_op`` and ``p_op_cond`` are optional fields which specify the base operation and the
+condition over the different fields of the instruction which when satisfied results in the instruction being recognized as the
+pseudo-op mentioned in ``mnemonics``. As an example, ``zext.h`` is a pseudo-op of ``pack`` in RV32 and packw in RV64 with ``rs2``
+equal to ``x0``. Covergroup for ``zext.h`` pseudo-op can be expressed as follows: ::
+
+    zext.h_32:
+        config: 
+          - check ISA:=regex(.*RV32.*B.*)
+          - check ISA:=regex(.*RV32.*Zbb.*)
+        mnemonics: 
+          zext.h: 0
+        base_op: packw
+        p_op_cond: rs2 == x0
+        ...
+
+    zext.h_64:
+        config: 
+          - check ISA:=regex(.*RV64.*B.*)
+          - check ISA:=regex(.*RV64.*Zbb.*)
+        mnemonics: 
+          zext.h: 0
+        base_op: pack
+        p_op_cond: rs2 == x0
+        ...
+
+The ``expand_cgf`` method defined in ``cgf_normalize.py`` goes through every covergroup in the working cgf dictionary. If it encounters
+``opcode`` node, a deprecation warning is printed and ``opcode`` is renamed to ``mnemonics``. The method also facilitates checks to see
+if ``base_op`` and ``p_op_cond`` meets required conditions.
+
+While computing the coverage, if the decoded instruction under scrutiny is equal to the instruction mentioned in ``base_op`` of working
+covergroup, the conditions mentioned in ``p_op_cond`` are evaluated. If a match is found, the instruction defined in ``mnemonic`` field is
+assumed to be hit and the coverpoint hit statistics is updated accordingly. 
+
+Note
+####
+- The ``p_op_cond`` node is relevant only if the ``base_op`` node has been defined.
+- The ``mnemonics`` node is allowed to have multiple entries only if the ``base_op`` node is empty.

--- a/riscv_isac/__init__.py
+++ b/riscv_isac/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'info@incoresemi.com'
-__version__ = '0.12.0'
+__version__ = '0.13.0'

--- a/riscv_isac/cgf_normalize.py
+++ b/riscv_isac/cgf_normalize.py
@@ -6,6 +6,8 @@ import random
 import copy
 from riscv_isac.fp_dataset import *
 
+import time
+
 def twos(val,bits):
     '''
     Finds the twos complement of the number
@@ -557,14 +559,24 @@ def expand_cgf(cgf_files, xlen):
     :type cgf: list
     :type xlen: int
     '''
-
     cgf = utils.load_cgf(cgf_files)
     for labels, cats in cgf.items():
         if labels != 'datasets':
             # If 'opcode' found, rename it to 'mnemonics'
             if 'opcode' in cats:
                 logger.warning("Deprecated node used: 'opcode'. Use 'mnemonics' instead")
-                cgf[labels] = {'mnemonics' if k == 'opcode' else k: v for k, v in cgf[labels].items()}
+                
+                temp = cgf[labels]['opcode']
+                del cgf[labels]['opcode']
+                cgf[labels].insert(1, 'mnemonics', temp)
+
+                if 'base_op' in cats:
+                    if 'p_op_cond' not in cats:
+                        logger.error(f'p_op_cond node not found in {labels} label.')
+
+                    if len(cgf[labels]['mnemonics'].keys()) > 1:
+                        logger.error(f'Multiple instruction mnemonics found when base_op label defined in {labels} label.')
+
             for label,node in cats.items():
                 if isinstance(node,dict):
                     if 'abstract_comb' in node:

--- a/riscv_isac/cgf_normalize.py
+++ b/riscv_isac/cgf_normalize.py
@@ -549,7 +549,7 @@ def alternate(var, size, signed=True, fltr_func=None,scale_func=None):
 def expand_cgf(cgf_files, xlen):
     '''
     This function will replace all the abstract functions with their unrolled
-    coverpoints
+    coverpoints. It replaces node
 
     :param cgf_files: list of yaml file paths which together define the coverpoints
     :param xlen: XLEN of the riscv-trace
@@ -563,6 +563,10 @@ def expand_cgf(cgf_files, xlen):
         if labels != 'datasets':
             for label,node in cats.items():
                 if isinstance(node,dict):
+                    
+                    # If 'opcode' found, rename it to 'mnemonics'
+                    if 'opcode' in node:
+                        cats[label] = {'menmonics' if k == 'opcode' else k: v for k, v in cats[label].items()}
                     if 'abstract_comb' in node:
                         temp = node['abstract_comb']
                         del node['abstract_comb']

--- a/riscv_isac/cgf_normalize.py
+++ b/riscv_isac/cgf_normalize.py
@@ -566,6 +566,7 @@ def expand_cgf(cgf_files, xlen):
                     
                     # If 'opcode' found, rename it to 'mnemonics'
                     if 'opcode' in node:
+                        logger.warning("Deprecated node used: 'opcode'. Use 'mnemonics' instead")
                         cats[label] = {'menmonics' if k == 'opcode' else k: v for k, v in cats[label].items()}
                     if 'abstract_comb' in node:
                         temp = node['abstract_comb']

--- a/riscv_isac/cgf_normalize.py
+++ b/riscv_isac/cgf_normalize.py
@@ -561,13 +561,12 @@ def expand_cgf(cgf_files, xlen):
     cgf = utils.load_cgf(cgf_files)
     for labels, cats in cgf.items():
         if labels != 'datasets':
+            # If 'opcode' found, rename it to 'mnemonics'
+            if 'opcode' in cats:
+                logger.warning("Deprecated node used: 'opcode'. Use 'mnemonics' instead")
+                cgf[labels] = {'mnemonics' if k == 'opcode' else k: v for k, v in cgf[labels].items()}
             for label,node in cats.items():
                 if isinstance(node,dict):
-                    
-                    # If 'opcode' found, rename it to 'mnemonics'
-                    if 'opcode' in node:
-                        logger.warning("Deprecated node used: 'opcode'. Use 'mnemonics' instead")
-                        cats[label] = {'menmonics' if k == 'opcode' else k: v for k, v in cats[label].items()}
                     if 'abstract_comb' in node:
                         temp = node['abstract_comb']
                         del node['abstract_comb']

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -986,7 +986,7 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, addr_pairs
         stats_queue.close()
 
 def compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xlen, addr_pairs
-        , dump, cov_labels, sig_addrs, window_size, no_count=True, procs=1):
+        , dump, cov_labels, sig_addrs, window_size, no_count=False, procs=1):
     '''Compute the Coverage'''
 
     global arch_state

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -723,7 +723,6 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, addr_pairs
                             if 'base_op' in value:
                                 # If base-op is the current instruction name, check for the p_op_cond node
                                 # If conditions satisfy, the instruction is equivalent to the mnemonic
-                                # Update hit statistics of the mnemonic
                                 if value['base_op'] == instr.instr_name:
                                     if 'p_op_cond' in value:
                                         conds = value['p_op_cond']
@@ -745,6 +744,7 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, addr_pairs
                                             logger.error('Multiple nodes found when base_op and p_op_cond defined.')
                                         mnemonic = mnemonic[0]
                                         
+                                        # Update hit statistics of the mnemonic
                                         if is_found:
                                             if value[req_node][mnemonic] == 0:
                                                 stats.ucovpt.append('mnemonic : ' + mnemonic)

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -614,19 +614,23 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, addr_pairs
                 rs1_type = instr.rs1[1]
                 rs1 = rs1_type + str(instr.rs1[0])
                 nxf_rs1 = instr.rs1[0]
+                exec(f'{rs1} = rs1')
             if instr.rs2 is not None:
                 rs2_type = instr.rs2[1]
                 rs2 = rs2_type + str(instr.rs2[0])
                 nxf_rs2 = instr.rs2[0]
+                exec(f'{rs2} = rs2')
             if instr.rs3 is not None:
                 rs3_type = instr.rs3[1]
                 rs3 = rs3_type + str(instr.rs3[0])
                 nxf_rs3 = instr.rs3[0]
+                exec(f'{rs3} = rs3')
             if instr.rd is not None:
                 is_rd_valid = True
                 rd_type = instr.rd[1]
                 rd = rd_type + str(instr.rd[0])
                 nxf_rd = instr.rd[0]
+                exec(f'{rd} = rd')
             else:
                 is_rd_valid = False
             if instr.imm is not None:
@@ -727,19 +731,10 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, addr_pairs
                                 if instr.instr_name == value['base_op']:
                                     
                                     conds = value['p_op_cond']
-                                    conds = conds.split('and')
-                                    conds = [cond.replace(' ', '').split('==') for cond in conds]
-
                                     # Construct and evaluate conditions
                                     is_found = True
-                                    for each in conds:
-                                        if each[0].find('imm') != -1:
-                                            condition = each[0] + "==" + each[1]
-                                        else:
-                                            condition = each[0] + "=='" + each[1] + "'"
-                                        if not eval(condition):
-                                            is_found = False
-                                            break
+                                    if not eval(conds):
+                                        is_found = False
                                     
                                     mnemonic = list(value[req_node].keys())
                                     mnemonic = mnemonic[0]

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -479,7 +479,7 @@ def merge_coverage(inp_files, cgf, detailed, xlen, p=1):
     temp = merge_fn(files,cgf,p)
     for cov_labels, value in temp.items():
         for categories in value:
-            if categories not in ['cond','config','ignore','total_coverage','coverage']:
+            if categories not in ['cond','config','ignore','total_coverage','coverage', 'base_op', 'p_op_cond']:
                 for coverpoints, coverage in value[categories].items():
                     if coverpoints in cgf[cov_labels][categories]:
                         cgf[cov_labels][categories][coverpoints] += coverage

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -576,10 +576,10 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, addr_pairs
             commitvalue = instr.reg_commit
 
             # assign default values to operands
-            rs1 = 0
-            rs2 = 0
-            rs3 = 0
-            rd  = 0
+            nxf_rs1 = 0
+            nxf_rs2 = 0
+            nxf_rs3 = 0
+            nxf_rd  = 0
             rs1_type = 'x'
             rs2_type = 'x'
             rs3_type = 'f'
@@ -926,7 +926,7 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, addr_pairs
 
             if instr.instr_name in ['sh','sb','sw','sd','c.sw','c.sd','c.swsp','c.sdsp'] and sig_addrs:
                 store_address = rs1_val + imm_val
-                store_val = '0x'+arch_state.x_rf[rs2]
+                store_val = '0x'+arch_state.x_rf[nxf_rs2]
                 for start, end in sig_addrs:
                     if store_address >= start and store_address <= end:
                         logger.debug('Signature update : ' + str(hex(store_address)))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.12.0
+current_version = 0.13.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = [ ]
 
 setup(
     name='riscv_isac',
-    version='0.12.0',
+    version='0.13.0',
     description="RISC-V ISAC",
     long_description=readme + '\n\n',
     classifiers=[


### PR DESCRIPTION
This pull request is related to issue #36 concerning the adoption of support for pseudoinstructions in covergroups. The covergroup format is modified to comply with this feature addition. `opcode` field is dropped and `mnemonics` field is used to list instructions in the covergroup. Two new fields are added to specify the alternate definition of the pseudoinstruction in terms of its base instruction. The base instruction can be mentioned under the `base_op` node and the necessary conditions required to make it congruent to the pseudoinstruction can be mentioned under the `p_op_cond` node.

ISAC, during the process of computation of coverage of the pseudoinstruction covergroup, compares the current instruction object under scrutiny with the pseudoinstruction mentioned in `mnemonics` node and also the with the definition in terms of the base instruction.