### PR TITLE
Error reporting for missing covergroup corresponding to input coverlabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.2] - 2022-05-23
+- Error reporting for missing coverlabel in cgf file
+
 ## [0.13.1] - 2022-05-07
 - Fix mistune version for doc builds.
 

--- a/riscv_isac/__init__.py
+++ b/riscv_isac/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'info@incoresemi.com'
-__version__ = '0.13.1'
+__version__ = '0.13.2'

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -1012,6 +1012,11 @@ def compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xle
                 del temp[groups]
         cgf = temp
 
+    # If cgf does not have the covergroup pertaining to the cover-label, throw error and exit    
+    if not cgf:
+        logger.err('Covergroup(s) for ' + str(cov_labels) + ' not found')
+        sys.exit(1)
+
     if dump is not None:
         dump_f = open(dump, 'w')
         dump_f.write(ruamel.yaml.round_trip_dump(cgf, indent=5, block_seq_indent=3))

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -1012,7 +1012,8 @@ def compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xle
                 del temp[groups]
         cgf = temp
 
-    # If cgf does not have the covergroup pertaining to the cover-label, throw error and exit    
+    # If cgf does not have the covergroup pertaining to the cover-label, throw error
+    # and exit    
     if not cgf:
         logger.err('Covergroup(s) for ' + str(cov_labels) + ' not found')
         sys.exit(1)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.13.1
+current_version = 0.13.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = [ ]
 
 setup(
     name='riscv_isac',
-    version='0.13.1',
+    version='0.13.2',
     description="RISC-V ISAC",
     long_description=readme + '\n\n',
     classifiers=[


### PR DESCRIPTION
When the covergroup corresponding to input coverlabel is absent in the given CGF file, ISAC continues to compute coverage using an empty cgf dictionary after filtration. This is an erroneous case and is not reported properly. The error becomes incomprehensible whilst computation of coverage using riscof.

This patch reports the error appropriately and mentions the requisite covergroups that should be present in the cgf file.