### PR TITLE
Log redundant coverpoints during normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.17.0] - 2022-10-25
+- Add a CLI flag to explicitly log the redundant coverpoints while normalizing the CGF files
+
 ## [0.16.1] - 2022-10-20
 - Fix length of commitval to 32 bits if flen is 32 for f registers in sail parser.
 

--- a/riscv_isac/__init__.py
+++ b/riscv_isac/__init__.py
@@ -4,5 +4,5 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'info@incoresemi.com'
-__version__ = '0.16.1'
+__version__ = '0.17.0'
 

--- a/riscv_isac/cgf_normalize.py
+++ b/riscv_isac/cgf_normalize.py
@@ -549,7 +549,7 @@ def alternate(var, size, signed=True, fltr_func=None,scale_func=None):
     #return [(coverpoint,"Alternate") for coverpoint in coverpoints]
 
 
-def expand_cgf(cgf_files, xlen,flen):
+def expand_cgf(cgf_files, xlen,flen, log_redundant=False):
     '''
     This function will replace all the abstract functions with their unrolled
     coverpoints. It replaces node
@@ -616,6 +616,8 @@ def expand_cgf(cgf_files, xlen,flen):
                                         +" in "+labels+": "+str(e) )
                             else:
                                 for cp,comment in exp_cp:
+                                    if log_redundant and cp in cgf[labels][label]:
+                                        logger.warn(f'Redundant coverpoint during normalization: {cp}')
                                     cgf[labels][label].insert(l+i,cp,coverage,comment=comment)
                                     i += 1
     return dict(cgf)

--- a/riscv_isac/main.py
+++ b/riscv_isac/main.py
@@ -126,10 +126,14 @@ def cli(verbose):
         default = 1,
         help = 'Set number of processes to calculate coverage'
 )
+@click.option('--log-redundant',
+        is_flag = True,
+        help = "Log redundant coverpoints during normalization"
+)
 
 def coverage(elf,trace_file, window_size, cgf_file, detailed,parser_name, decoder_name, parser_path, decoder_path,output_file, test_label,
-        sig_label, dump,cov_label, xlen, flen, no_count, procs):
-    isac(output_file,elf,trace_file, window_size, expand_cgf(cgf_file,int(xlen),int(flen)), parser_name, decoder_name, parser_path, decoder_path, detailed, test_label,
+        sig_label, dump,cov_label, xlen, flen, no_count, procs, log_redundant):
+    isac(output_file,elf,trace_file, window_size, expand_cgf(cgf_file,int(xlen),int(flen),log_redundant), parser_name, decoder_name, parser_path, decoder_path, detailed, test_label,
             sig_label, dump, cov_label, int(xlen), int(flen), no_count, procs)
 
 @cli.command(help = "Merge given coverage files.")
@@ -164,9 +168,13 @@ def coverage(elf,trace_file, window_size, cgf_file, detailed,parser_name, decode
         help="FLEN value for the ISA."
 )
 @click.option('--xlen','-x',type=click.Choice(['32','64']),default='32',help="XLEN value for the ISA.")
-def merge(files,detailed,p,cgf_file,output_file,flen,xlen):
+@click.option('--log-redundant',
+        is_flag = True,
+        help = "Log redundant coverpoints during normalization"
+)
+def merge(files,detailed,p,cgf_file,output_file,flen,xlen,log_redundant):
     rpt = cov.merge_coverage(
-            files,expand_cgf(cgf_file,int(xlen),int(flen)),detailed,p)
+            files,expand_cgf(cgf_file,int(xlen),int(flen),log_redundant),detailed,p)
     if output_file is None:
         logger.info('Coverage Report:')
         logger.info('\n\n' + rpt)
@@ -192,10 +200,14 @@ def merge(files,detailed,p,cgf_file,output_file,flen,xlen):
     )
 @click.option('--xlen','-x',type=click.Choice(['32','64']),default='32',help="XLEN value for the ISA.")
 @click.option('--flen','-f',type=click.Choice(['32','64']),default='32',help="FLEN value for the ISA.")
-def normalize(cgf_file,output_file,xlen,flen):
+@click.option('--log-redundant',
+        is_flag = True,
+        help = "Log redundant coverpoints during normalization"
+)
+def normalize(cgf_file,output_file,xlen,flen,log_redundant):
     logger.info("Writing normalized CGF to "+str(output_file))
     with open(output_file,"w") as outfile:
-        utils.dump_yaml(expand_cgf(cgf_file,int(xlen),int(flen)),outfile)
+        utils.dump_yaml(expand_cgf(cgf_file,int(xlen),int(flen),log_redundant),outfile)
 
 @cli.command(help = 'Setup the plugin which uses the information from RISCV Opcodes repository to decode.')
 @click.option('--url',

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.16.1
+current_version = 0.17.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = [ ]
 
 setup(
     name='riscv_isac',
-    version='0.16.1',
+    version='0.17.0',
     description="RISC-V ISAC",
     long_description=readme + '\n\n',
     classifiers=[


### PR DESCRIPTION
Add the CLI flag `--log-redundant` to explicitly log the redundant coverpoints while normalizing the CGF files.
Closes #44.