### PR TITLE
Implement capturing multiple signature updates per coverpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.17.0] - 2022-10-25
+- Improve data propagation reports to capture multiple signature updates per coverpoint
+- Add a CLI flag to explicitly log the redundant coverpoints while normalizing the CGF files
+
 ## [0.16.1] - 2022-10-20
 - Fix length of commitval to 32 bits if flen is 32 for f registers in sail parser.
 

--- a/docs/source/cgf.rst
+++ b/docs/source/cgf.rst
@@ -334,7 +334,11 @@ A covergroup contains the following nodes:
         * **csrcomb-str**  
             This string is interpreted as a valid python statement/expression which evaluates to a Boolean value. The variables available for use in the expression are as follows:
                 
-                * ``csr_name`` : The value (as of the end of previous instruction) in the CSR whose name is specified by csr_name.
+                * ``csr_name`` : The value (as of the end of current instruction) in the CSR whose name is specified by csr_name.
+
+                * ``old("csr_name")`` : The value (as of the end of previous instruction) in the CSR whose name is specified by csr_name.
+
+                * ``write("csr_name")`` : The value being written to the CSR in the current instruction whose name is specified by csr_name.
 
                 * ``xlen`` : The length of the regsiters in the machine.
 
@@ -366,6 +370,12 @@ A covergroup contains the following nodes:
                 .. code-block:: python
 
                     mstatus && (0x8) == 0x8
+
+            4. A coverpoint which checks whether the *M* bit of the value being written to *misa* register is unset and the final value that the register assumes has that bit still set.
+
+                .. code-block:: python
+
+                    (write("misa") >> 12) & 1 == 0 and misa & 0x1000 == 0x1000
 
 * **cross_comb**
     *This node is optional.*

--- a/docs/source/dpr.rst
+++ b/docs/source/dpr.rst
@@ -1,0 +1,12 @@
+***********************
+Data Propagation Report
+***********************
+
+The data propagation details quality analysis on the data propagation occurring within the test/application. It reports
+the following statistics about coverpoint hits and related signature updates:
+
+* **STAT1** : Number of instructions that hit unique coverpoints and update the signature
+* **STAT2** : Number of instructions that hit covepoints which are not unique but still update the signature (completely or partially)
+* **STAT3** : Number of instructions that hit a unique coverpoint but do not update the signature completely
+* **STAT4** : Number of multiple signature updates for the same coverpoint
+* **STAT5** : Number of times the signature was overwritten

--- a/riscv_isac/InstructionObject.py
+++ b/riscv_isac/InstructionObject.py
@@ -218,12 +218,12 @@ class instructionObject():
                     store_instrs = ['sd'] if xlen == 64 else ['sw']
             instrs_to_track.append(store_instrs)
         elif self.instr_name in instrs_sig_mutable:
-            if self.reg_commit is not None:
-                reg = self.reg_commit[0] + self.reg_commit[1]
+            if self.rd is not None:
+                reg = self.rd[1] + str(self.rd[0])
                 regs_to_track_mutable.append(reg)
         else:
-            if self.reg_commit is not None:
-                reg = self.reg_commit[0] + self.reg_commit[1]
+            if self.rd is not None:
+                reg = self.rd[1] + str(self.rd[0])
                 regs_to_track_immutable.append(reg)
 
             if self.instr_name in instrs_fcsr_affected:

--- a/riscv_isac/InstructionObject.py
+++ b/riscv_isac/InstructionObject.py
@@ -1,6 +1,17 @@
 import struct
 
-
+instrs_sig_mutable = ['auipc','jal','jalr']
+instrs_sig_update = ['sh','sb','sw','sd','c.sw','c.sd','c.swsp','c.sdsp','fsw','fsd',\
+        'c.fsw','c.fsd','c.fswsp','c.fsdsp']
+instrs_no_reg_tracking = ['beq','bne','blt','bge','bltu','bgeu','fence','c.j','c.jal','c.jalr',\
+        'c.jr','c.beqz','c.bnez'] + instrs_sig_update
+instrs_fcsr_affected = ['fmadd.s','fmsub.s','fnmsub.s','fnmadd.s','fadd.s','fsub.s','fmul.s','fdiv.s',\
+        'fsqrt.s','fmin.s','fmax.s','fcvt.w.s','fcvt.wu.s','feq.s','flt.s',\
+        'fle.s','fcvt.s.w','fcvt.s.wu','fcvt.l.s','fcvt.lu.s','fcvt.s.l',\
+        'fcvt.s.lu', 'fmadd.d','fmsub.d','fnmsub.d','fnmadd.d','fadd.d','fsub.d',\
+        'fmul.d','fdiv.d','fsqrt.d','fmin.d','fmax.d','fcvt.s.d','fcvt.d.s',\
+        'feq.d','flt.d','fle.d','fcvt.w.d','fcvt.wu.d','fcvt.l.d','fcvt.lu.d',\
+        'fcvt.d.l','fcvt.d.lu']
 unsgn_rs1 = ['sw','sd','sh','sb','ld','lw','lwu','lh','lhu','lb', 'lbu','flw','fld','fsw','fsd',\
         'bgeu', 'bltu', 'sltiu', 'sltu','c.lw','c.ld','c.lwsp','c.ldsp',\
         'c.sw','c.sd','c.swsp','c.sdsp','mulhu','divu','remu','divuw',\
@@ -112,6 +123,10 @@ class instructionObject():
         self.rd_nregs = 1
 
 
+    def is_sig_update(self):
+        return self.instr_name in instrs_sig_update
+
+
     def evaluate_instr_vars(self, xlen, flen, arch_state, csr_regfile, instr_vars):
         '''
         This function populates the provided instr_vars dictionary
@@ -177,6 +192,84 @@ class instructionObject():
         ext_specific_vars = self.evaluate_instr_var("ext_specific_vars", instr_vars, arch_state, csr_regfile)
         if ext_specific_vars is not None:
             instr_vars.update(ext_specific_vars)
+
+
+    def get_elements_to_track(self, xlen):
+        '''
+        This function returns the elements to track to aid in monitoring signature updates and related statistics.
+        The returned value is a tuple of three elements:
+
+        - The first element is a list of registers to track whose values cannot be modified before storing
+        - The second element is a list of registers to track whose value can be modified prior to storing
+        - The third element is a list of instructions to track for signature updates other than those of tracked registers (mostly used for branch instructions)
+        '''
+        regs_to_track_immutable = []
+        regs_to_track_mutable = []
+        instrs_to_track = []
+
+        if self.instr_name in instrs_no_reg_tracking:
+            store_instrs = []
+            if self.is_sig_update():
+                store_instrs = [self.instr_name]
+            else:
+                if self.instr_name.startswith("c."):
+                    store_instrs = ['sd','c.sdsp'] if xlen == 64 else ['sw','c.swsp']
+                else:
+                    store_instrs = ['sd'] if xlen == 64 else ['sw']
+            instrs_to_track.append(store_instrs)
+        elif self.instr_name in instrs_sig_mutable:
+            if self.reg_commit is not None:
+                reg = self.reg_commit[0] + self.reg_commit[1]
+                regs_to_track_mutable.append(reg)
+        else:
+            if self.reg_commit is not None:
+                reg = self.reg_commit[0] + self.reg_commit[1]
+                regs_to_track_immutable.append(reg)
+
+            if self.instr_name in instrs_fcsr_affected:
+                regs_to_track_immutable.append('fcsr')
+
+            if self.csr_commit is not None:
+                for commit in self.csr_commit:
+                    if commit[0] == "CSR":
+                        csr_reg = commit[1]
+                        if csr_reg not in regs_to_track_immutable:
+                            regs_to_track_immutable.append(csr_reg)
+
+        return (regs_to_track_immutable, regs_to_track_mutable, instrs_to_track)
+
+
+    def get_changed_regs(self, arch_state, csr_regfile):
+        '''
+        This function returns a list of registers whose value will be changed as
+        a result of executing this instruction.
+
+        :param csr_regfile: Architectural state of CSR register files
+        :param instr_vars: Dictionary to be populated by the evaluated instruction variables
+        '''
+        changed_regs = []
+
+        if self.reg_commit is not None:
+            reg = self.reg_commit[0] + self.reg_commit[1]
+
+            prev_value = None
+            if self.reg_commit[0] == 'x':
+                prev_value = arch_state.x_rf[int(self.reg_commit[1])]
+            elif self.reg_commit[0] == 'f':
+                prev_value = arch_state.f_rf[int(self.reg_commit[1])]
+
+            if prev_value != str(self.reg_commit[2][2:]): # this is a string check, but should we do an exact number check?
+                changed_regs.append(reg)
+
+        if self.csr_commit is not None:
+            for commit in self.csr_commit:
+                if commit[0] == "CSR":
+                    csr_reg = commit[1]
+
+                    if csr_regfile[csr_reg] != str(commit[2][2:]):
+                        changed_regs.append(csr_reg)
+
+        return changed_regs
 
 
     def update_arch_state(self, arch_state, csr_regfile):

--- a/riscv_isac/InstructionObject.py
+++ b/riscv_isac/InstructionObject.py
@@ -4,7 +4,7 @@ instrs_sig_mutable = ['auipc','jal','jalr']
 instrs_sig_update = ['sh','sb','sw','sd','c.sw','c.sd','c.swsp','c.sdsp','fsw','fsd',\
         'c.fsw','c.fsd','c.fswsp','c.fsdsp']
 instrs_no_reg_tracking = ['beq','bne','blt','bge','bltu','bgeu','fence','c.j','c.jal','c.jalr',\
-        'c.jr','c.beqz','c.bnez'] + instrs_sig_update
+        'c.jr','c.beqz','c.bnez', 'c.ebreak'] + instrs_sig_update
 instrs_fcsr_affected = ['fmadd.s','fmsub.s','fnmsub.s','fnmadd.s','fadd.s','fsub.s','fmul.s','fdiv.s',\
         'fsqrt.s','fmin.s','fmax.s','fcvt.w.s','fcvt.wu.s','feq.s','flt.s',\
         'fle.s','fcvt.s.w','fcvt.s.wu','fcvt.l.s','fcvt.lu.s','fcvt.s.l',\

--- a/riscv_isac/__init__.py
+++ b/riscv_isac/__init__.py
@@ -4,5 +4,5 @@
 
 __author__ = """InCore Semiconductors Pvt Ltd"""
 __email__ = 'info@incoresemi.com'
-__version__ = '0.16.1'
+__version__ = '0.17.0'
 

--- a/riscv_isac/cgf_normalize.py
+++ b/riscv_isac/cgf_normalize.py
@@ -549,7 +549,7 @@ def alternate(var, size, signed=True, fltr_func=None,scale_func=None):
     #return [(coverpoint,"Alternate") for coverpoint in coverpoints]
 
 
-def expand_cgf(cgf_files, xlen,flen):
+def expand_cgf(cgf_files, xlen,flen, log_redundant=False):
     '''
     This function will replace all the abstract functions with their unrolled
     coverpoints. It replaces node
@@ -616,6 +616,8 @@ def expand_cgf(cgf_files, xlen,flen):
                                         +" in "+labels+": "+str(e) )
                             else:
                                 for cp,comment in exp_cp:
+                                    if log_redundant and cp in cgf[labels][label]:
+                                        logger.warn(f'Redundant coverpoint during normalization: {cp}')
                                     cgf[labels][label].insert(l+i,cp,coverage,comment=comment)
                                     i += 1
     return dict(cgf)

--- a/riscv_isac/constants.py
+++ b/riscv_isac/constants.py
@@ -9,9 +9,9 @@ cwd = os.getcwd()
 dpr_template = '''
 # Data Propagation Report
 
-- **STAT1** : Number of instructions that hit unique coverpoints and update the signature.
-- **STAT2** : Number of instructions that hit covepoints which are not unique but still update the signature
-- **STAT3** : Number of instructions that hit a unique coverpoint but do not update signature
+- **STAT1** : Number of instructions that hit unique coverpoints and update the signature
+- **STAT2** : Number of instructions that hit covepoints which are not unique but still update the signature (completely or partially)
+- **STAT3** : Number of instructions that hit a unique coverpoint but do not update the signature completely
 - **STAT4** : Number of multiple signature updates for the same coverpoint
 - **STAT5** : Number of times the signature was overwritten
 
@@ -57,10 +57,15 @@ dpr_template = '''
 
 ## Details of STAT1:
 
-- The first column indicates the signature address and the data at that location in hexadecimal in the following format: 
+- The first column indicates the signature address(es) and the data at that location in hexadecimal in the following format:
   ```
-  [Address]
-  Data
+  [Address1]
+  Data1
+
+  [Address2]
+  Data2
+
+  ...
   ```
 
 - The second column captures all the coverpoints which have been captured by that particular signature location

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -900,14 +900,14 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
                             tracked_regs_immutable.discard(rs2)
                             tracked_regs_mutable.discard(rs2)
                             del instr_addr_of_tracked_reg[rs2]
-                        elif instrs_to_track and instr.instr_name in instrs_to_track[0][0]:
-                            stat_meta = instr_stat_meta_at_addr[instrs_to_track[0][1]]
+                        elif tracked_instrs and instr.instr_name in tracked_instrs[0][0]:
+                            stat_meta = instr_stat_meta_at_addr[tracked_instrs[0][1]]
                             stat_meta[2] += 1
                             stat_meta[3] -= 1
                             stat_meta[6].append(store_address)
                             stat_meta[7].append(store_val)
                             stats.last_meta = [store_address, store_val, stat_meta[4], stat_meta[5]]
-                            del instrs_to_track[0]
+                            del tracked_instrs[0]
                         else:
                             if len(stats.last_meta):
                                 _log = 'Last Coverpoint : ' + str(stats.last_meta[2]) + '\n'

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -127,6 +127,39 @@ class cross():
         for i in range(len(self.queue)):
             self.compute()
 
+        # update stats one last time for remaining elements
+        for key_instr_addr in list(self.instr_stat_meta_at_addr.keys()):
+            stat_meta = self.instr_stat_meta_at_addr[key_instr_addr]
+            if stat_meta[0]: # is_ucovpt
+                if stat_meta[2] == stat_meta[1]: # num_observed == num_expected
+                    # update STAT1 with (store_addresses, store_vals, covpt, code_seq)
+                    self.stats.stat1.append((stat_meta[6], stat_meta[7], stat_meta[4], stat_meta[5]))
+                elif stat_meta[2] < stat_meta[1]: # num_observed < num_expected
+                    # update STAT3 with code sequence
+                    self.stats.stat3.append('\n'.join(stat_meta[5]))
+            else: # not is_ucovpt
+                if stat_meta[2] > 0: # num_observed > 0
+                    # update STAT2
+                    _log = 'Op without unique coverpoint updates Signature\n'
+
+                    _log += ' -- Code Sequence:\n'
+                    for op in stat_meta[5]:
+                        _log += '      ' + op + '\n'
+
+                    _log += ' -- Signature Addresses:\n'
+                    for store_address, store_val in zip(stat_meta[6], stat_meta[7]):
+                        _log += '      Address: {0} Data: {1}\n'.format(
+                                str(hex(store_address)), store_val)
+
+                    _log += ' -- Redundant Coverpoints hit by the op\n'
+                    for c in stat_meta[4]:
+                        _log += '      - ' + str(c) + '\n'
+
+                    logger.warn(_log)
+                    self.stats.stat2.append(_log + '\n\n')
+
+            del self.instr_stat_meta_at_addr[key_instr_addr]
+
     def compute_cross_cov(self):
         '''
         Check whether the cross coverage coverpoint was hit or not and update the metric
@@ -1134,6 +1167,39 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
                 else:
                     hit_covpts = []
     else:
+        # update stats one last time for the remaining elements
+        for key_instr_addr in list(instr_stat_meta_at_addr.keys()):
+            stat_meta = instr_stat_meta_at_addr[key_instr_addr]
+            if stat_meta[0]: # is_ucovpt
+                if stat_meta[2] == stat_meta[1]: # num_observed == num_expected
+                    # update STAT1 with (store_addresses, store_vals, covpt, code_seq)
+                    stats.stat1.append((stat_meta[6], stat_meta[7], stat_meta[4], stat_meta[5]))
+                elif stat_meta[2] < stat_meta[1]: # num_observed < num_expected
+                    # update STAT3 with code sequence
+                    stats.stat3.append('\n'.join(stat_meta[5]))
+            else: # not is_ucovpt
+                if stat_meta[2] > 0: # num_observed > 0
+                    # update STAT2
+                    _log = 'Op without unique coverpoint updates Signature\n'
+
+                    _log += ' -- Code Sequence:\n'
+                    for op in stat_meta[5]:
+                        _log += '      ' + op + '\n'
+
+                    _log += ' -- Signature Addresses:\n'
+                    for store_address, store_val in zip(stat_meta[6], stat_meta[7]):
+                        _log += '      Address: {0} Data: {1}\n'.format(
+                                str(hex(store_address)), store_val)
+
+                    _log += ' -- Redundant Coverpoints hit by the op\n'
+                    for c in stat_meta[4]:
+                        _log += '      - ' + str(c) + '\n'
+
+                    logger.warn(_log)
+                    stats.stat2.append(_log + '\n\n')
+
+            del instr_stat_meta_at_addr[key_instr_addr]
+
         # if no_count option is set, return rcgf
         # else return cgf
         if not no_count:

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -858,7 +858,7 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
                             if len(stats.last_meta):
                                 _log = 'Last Coverpoint : ' + str(stats.last_meta[2]) + '\n'
                                 _log += 'Last Code Sequence : \n\t-' + '\n\t-'.join(stats.last_meta[3]) + '\n'
-                                _log +='Current Store : [{0}] : {1} -- Store: [{2}]:{3}\n'.format(\
+                                _log += 'Current Store : [{0}] : {1} -- Store: [{2}]:{3}\n'.format(\
                                     str(hex(instr.instr_addr)), mnemonic,
                                     str(hex(store_address)),
                                     store_val)
@@ -873,11 +873,11 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
                 if stat_meta[3] == 0: # num_remaining == 0
                     if stat_meta[0]: # is_ucovpt
                         if stat_meta[2] == stat_meta[1]: # num_observed == num_expected
-                            # update STAT1 with (store_address, store_vals, covpt, code_seq)
+                            # update STAT1 with (store_addresses, store_vals, covpt, code_seq)
                             stats.stat1.append((stat_meta[6], stat_meta[7], stat_meta[4], stat_meta[5]))
                         elif stat_meta[2] < stat_meta[1]: # num_observed < num_expected
-                            # update STAT3 with (num_obs, num_exp, store_addresses, store_vals, covpt, code_seq)
-                            stats.stats3.append((stat_meta[2], stat_meta[1], stat_meta[6], stat_meta[7], stat_meta[4], stat_meta[5]))
+                            # update STAT3 with code sequence
+                            stats.stat3.append('\n'.join(stat_meta[5]))
                     else: # not is_ucovpt
                         # update STAT2
                         _log = 'Op without unique coverpoint updates Signature\n'
@@ -1139,9 +1139,10 @@ def compute(trace_file, test_name, cgf, parser_name, decoder_name, detailed, xle
 
         cov_set = set()
         count = 1
-        stat5_log = []
-        for addr,val,cover,code in stats.stat1:
-            sig = ('[{0}]<br>{1}'.format(str(hex(addr)), str(val)))
+        for addrs,vals,cover,code in stats.stat1:
+            sig = ''
+            for addr, val in zip(addrs, vals):
+                sig += '[{0}]<br>{1}'.format(str(hex(addr)), str(val)) + '<br>\n'
             cov = ''
             for c in cover:
                 cov += '- ' + str(c) + '<br>\n'

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -879,24 +879,25 @@ def compute_per_line(queue, event, cgf_queue, stats_queue, cgf, xlen, flen, addr
                             # update STAT3 with code sequence
                             stats.stat3.append('\n'.join(stat_meta[5]))
                     else: # not is_ucovpt
-                        # update STAT2
-                        _log = 'Op without unique coverpoint updates Signature\n'
+                        if stat_meta[2] > 0: # num_observed > 0
+                            # update STAT2
+                            _log = 'Op without unique coverpoint updates Signature\n'
 
-                        _log += ' -- Code Sequence:\n'
-                        for op in stat_meta[5]:
-                            _log += '      ' + op + '\n'
+                            _log += ' -- Code Sequence:\n'
+                            for op in stat_meta[5]:
+                                _log += '      ' + op + '\n'
 
-                        _log += ' -- Signature Addresses:\n'
-                        for store_address, store_val in zip(stat_meta[6], stat_meta[7]):
-                            _log += '      Address: {0} Data: {1}\n'.format(
-                                    str(hex(store_address)), store_val)
+                            _log += ' -- Signature Addresses:\n'
+                            for store_address, store_val in zip(stat_meta[6], stat_meta[7]):
+                                _log += '      Address: {0} Data: {1}\n'.format(
+                                        str(hex(store_address)), store_val)
 
-                        _log += ' -- Redundant Coverpoints hit by the op\n'
-                        for c in stat_meta[4]:
-                            _log += '      - ' + str(c) + '\n'
+                            _log += ' -- Redundant Coverpoints hit by the op\n'
+                            for c in stat_meta[4]:
+                                _log += '      - ' + str(c) + '\n'
 
-                        logger.warn(_log)
-                        stats.stat2.append(_log + '\n\n')
+                            logger.warn(_log)
+                            stats.stat2.append(_log + '\n\n')
 
                     del instr_stat_meta_at_addr[key_instr_addr]
 

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -277,7 +277,6 @@ class cross():
             for start, end in self.sig_addrs:
                 if store_address >= start and store_address <= end:
                     logger.debug('Signature update : ' + str(hex(store_address)))
-                    self.stats.stat5.append((store_address, store_val, [], stats.code_seq))
 
                     rs2 = instr_vars['rs2']
                     if rs2 in self.tracked_regs:

--- a/riscv_isac/coverage.py
+++ b/riscv_isac/coverage.py
@@ -221,6 +221,9 @@ class cross():
                     self.tracked_regs.remove(reg)
                     del self.instr_addr_of_tracked_reg[reg]
 
+                self.tracked_regs.add(reg)
+                self.instr_addr_of_tracked_reg[reg] = start_instr.instr_addr
+
             self.instr_stat_meta_at_addr[start_instr.instr_addr] = [hit_uniq_covpt, num_exp, 0, num_exp, [self.coverpoint], [], [], []]
 
             for i in range(len(self.ops)):

--- a/riscv_isac/main.py
+++ b/riscv_isac/main.py
@@ -126,10 +126,14 @@ def cli(verbose):
         default = 1,
         help = 'Set number of processes to calculate coverage'
 )
+@click.option('--log-redundant',
+        is_flag = True,
+        help = "Log redundant coverpoints during normalization"
+)
 
 def coverage(elf,trace_file, window_size, cgf_file, detailed,parser_name, decoder_name, parser_path, decoder_path,output_file, test_label,
-        sig_label, dump,cov_label, xlen, flen, no_count, procs):
-    isac(output_file,elf,trace_file, window_size, expand_cgf(cgf_file,int(xlen),int(flen)), parser_name, decoder_name, parser_path, decoder_path, detailed, test_label,
+        sig_label, dump,cov_label, xlen, flen, no_count, procs, log_redundant):
+    isac(output_file,elf,trace_file, window_size, expand_cgf(cgf_file,int(xlen),int(flen),log_redundant), parser_name, decoder_name, parser_path, decoder_path, detailed, test_label,
             sig_label, dump, cov_label, int(xlen), int(flen), no_count, procs)
 
 @cli.command(help = "Merge given coverage files.")
@@ -164,9 +168,13 @@ def coverage(elf,trace_file, window_size, cgf_file, detailed,parser_name, decode
         help="FLEN value for the ISA."
 )
 @click.option('--xlen','-x',type=click.Choice(['32','64']),default='32',help="XLEN value for the ISA.")
-def merge(files,detailed,p,cgf_file,output_file,flen,xlen):
+@click.option('--log-redundant',
+        is_flag = True,
+        help = "Log redundant coverpoints during normalization"
+)
+def merge(files,detailed,p,cgf_file,output_file,flen,xlen,log_redundant):
     rpt = cov.merge_coverage(
-            files,expand_cgf(cgf_file,int(xlen),int(flen)),detailed,p)
+            files,expand_cgf(cgf_file,int(xlen),int(flen),log_redundant),detailed,p)
     if output_file is None:
         logger.info('Coverage Report:')
         logger.info('\n\n' + rpt)
@@ -192,10 +200,14 @@ def merge(files,detailed,p,cgf_file,output_file,flen,xlen):
     )
 @click.option('--xlen','-x',type=click.Choice(['32','64']),default='32',help="XLEN value for the ISA.")
 @click.option('--flen','-f',type=click.Choice(['32','64']),default='32',help="FLEN value for the ISA.")
-def normalize(cgf_file,output_file,xlen,flen):
+@click.option('--log-redundant',
+        is_flag = True,
+        help = "Log redundant coverpoints during normalization"
+)
+def normalize(cgf_file,output_file,xlen,flen,log_redundant):
     logger.info("Writing normalized CGF to "+str(output_file))
     with open(output_file,"w") as outfile:
-        utils.dump_yaml(expand_cgf(cgf_file,int(xlen),int(flen)),outfile)
+        utils.dump_yaml(expand_cgf(cgf_file,int(xlen),int(flen),log_redundant),outfile)
 
 @cli.command(help = 'Setup the plugin which uses the information from RISCV Opcodes repository to decode.')
 @click.option('--url',

--- a/riscv_isac/plugins/c_sail.py
+++ b/riscv_isac/plugins/c_sail.py
@@ -17,7 +17,7 @@ irrespective of their original size.')
     instr_pattern_c_sail= re.compile(
         '\[\d*\]\s\[(.*?)\]:\s(?P<addr>[0-9xABCDEF]+)\s\((?P<instr>[0-9xABCDEF]+)\)\s*(?P<mnemonic>.*)')
     instr_pattern_c_sail_regt_reg_val = re.compile('(?P<regt>[xf])(?P<reg>[\d]+)\s<-\s(?P<val>[0-9xABCDEF]+)')
-    instr_pattern_c_sail_csr_reg_val = re.compile('(?P<CSR>CSR|clint::tick)\s(?P<reg>[a-z0-9]+)\s<-\s(?P<val>[0-9xABCDEF]+)')
+    instr_pattern_c_sail_csr_reg_val = re.compile('(?P<CSR>CSR|clint::tick)\s(?P<reg>[a-z0-9]+)\s<-\s(?P<val>[0-9xABCDEF]+)(?:\s\(input:\s(?P<input_val>[0-9xABCDEF]+)\))?')
     def extractInstruction(self, line):
         instr_pattern = self.instr_pattern_c_sail
         re_search = instr_pattern.search(line)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.16.1
+current_version = 0.17.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ test_requirements = [ ]
 
 setup(
     name='riscv_isac',
-    version='0.16.1',
+    version='0.17.0',
     description="RISC-V ISAC",
     long_description=readme + '\n\n',
     classifiers=[


### PR DESCRIPTION
This PR:
 * Implements capturing multiple signature updates per coverpoint for the data propagation report. It does so by tracking the registers affected by the instructions which hit the coverpoints. In places where tracking for registers is not possible (branch instructions, etc.), it simply looks for the occurrence of a series of instructions (usualy store instructions) to verify that the signature was propagated.
 * Adds support for evaluating coverage of tests generated for the `csr_comb` node
 * Adds a new CLI flag `--log-redundant` to explicitly log the redundant coverpoints while normalizing the CGF files.

Resolves #26,  resolves #44 and resolves #63.