### PR TITLE
Add support to find coverage of ```Zcb``` test suites

### DIFF
--- a/riscv_isac/InstructionObject.py
+++ b/riscv_isac/InstructionObject.py
@@ -25,7 +25,8 @@ unsgn_rs1 = ['sw','sd','sh','sb','ld','lw','lwu','lh','lhu','lb', 'lbu','flw','f
         'aes32esmi', 'aes32esi', 'aes32dsmi', 'aes32dsi','bclr','bext','binv',\
         'bset','zext.h','sext.h','sext.b','zext.b','zext.w','minu','maxu','orc.b','add.uw','sh1add.uw',\
         'sh2add.uw','sh3add.uw','slli.uw','clz','clzw','ctz','ctzw','cpop','cpopw','rev8',\
-        'bclri','bexti','binvi','bseti','fcvt.d.wu','fcvt.s.wu','fcvt.d.lu','fcvt.s.lu','c.flwsp']
+        'bclri','bexti','binvi','bseti','fcvt.d.wu','fcvt.s.wu','fcvt.d.lu','fcvt.s.lu','c.flwsp',\
+        'c.not', 'c.sext.b','c.sext.h','c.zext.b','c.zext.h','c.zext.w']
 unsgn_rs2 = ['bgeu', 'bltu', 'sltiu', 'sltu', 'sll', 'srl', 'sra','mulhu',\
         'mulhsu','divu','remu','divuw','remuw','aes64ds','aes64dsm','aes64es',\
         'aes64esm','aes64ks2','sm4ed','sm4ks','ror','rol','rorw','rolw','clmul',\

--- a/riscv_isac/data/constants.py
+++ b/riscv_isac/data/constants.py
@@ -495,6 +495,8 @@ arg_lut['c_uimm9splo'] = (6,2)
 arg_lut['c_uimm9sphi'] = (12, 12)
 arg_lut['c_uimm10sp_s'] = (12,7)
 arg_lut['c_uimm9sp_s'] = (12,7)
+arg_lut['c_uimm2'] = (6, 5)
+arg_lut['c_uimm1'] = (5, 5)
 
 arg_lut['rs1_p'] = (9,7)
 arg_lut['rs2_p'] = (4,2)

--- a/riscv_isac/data/rvopcodesdecoder.py
+++ b/riscv_isac/data/rvopcodesdecoder.py
@@ -346,6 +346,7 @@ class disassembler():
             # Fill arguments
             args = name_args[1]
             imm = ''
+            uimm = ''
             # Get extension
             file_name = args[-1]
             # If instruction from P extension
@@ -674,11 +675,21 @@ class disassembler():
                         # offset[5:3|8:6] and scalling by 8 ('000')
                         imm_temp = get_arg_val(arg)(mcode)
                         imm = imm_temp[3:] + imm_temp[0:3] + '000'
+                        
+                    if arg == 'c_uimm2':
+                        imm_temp = get_arg_val(arg)(mcode)
+                        uimm = imm_temp[1] + imm_temp[0]
+                        
+                    if arg == 'c_uimm1':
+                        imm_temp = get_arg_val(arg)(mcode)
+                        uimm = imm_temp + '0'
 
             if imm:
                 numbits = len(imm)
                 temp_instrobj.imm = disassembler.twos_comp(int(imm, 2), numbits)
                 temp_instrobj.inxFlg = self.inxFlag
+            elif uimm:
+                temp_instrobj.imm = int(uimm, 2)
             return temp_instrobj
         else:
             return None


### PR DESCRIPTION
This PR adds the support to find coverage of test suites for ```Zcb``` sub extension from Code Size Reduction Extension (Zce) 

riscv-non-isa/riscv-arch-test#364

- ```rvopcodesdecoder.py``` is updated to extract the immediate value for instructions in ```Zcb```. 

- Argument lookup table ```(arg_lut)```  is updated with required immediates and fields.

- ```unsgn_rs1``` list in ```instructionObject.py``` is updated with the instructions which has rs1 unsigned in ```Zcb```.